### PR TITLE
Create Pan_Yu_2021

### DIFF
--- a/Glycine/max/wip_marlene/Pan_Yu_2021
+++ b/Glycine/max/wip_marlene/Pan_Yu_2021
@@ -1,0 +1,18 @@
+gene_symbols:
+  - EcABCC8
+gene_symbol_long: Echinocloa colona ATP-binding cassette transporter
+gene_model_pub_name: MT249005
+gene_model_full_id: MT249005
+confidence: 5
+comments: 
+  - Overexpression of EcABCC8 (or its orthologs) in transgenic plants created glyphosate resistance. EcABCC8 knockout plants had decreased resistance to glyphosate.
+phenotype_synopsis: EcABCC8 codes for an efflux pump that 'extrudes' the herbicide glyphosate out of a cell's cytoplasm, making Echinochloa colona ('awnless barnyardgrass') glyphosate resistant.
+traits:
+  - entity_name: herbicide resistance
+    entity: OMIT:0025284
+  - entity_name: ABC-type transporter activity
+    entity: GO:0140359
+references:
+  - citation: Pan,Yu et.al, 2021
+    doi: 10.1073/pnas.2100136118
+    pmid: 33846264

--- a/Glycine/max/wip_marlene/Pan_Yu_2021
+++ b/Glycine/max/wip_marlene/Pan_Yu_2021
@@ -8,6 +8,8 @@ comments:
   - Overexpression of EcABCC8 (or its orthologs) in transgenic plants created glyphosate resistance. EcABCC8 knockout plants had decreased resistance to glyphosate.
 phenotype_synopsis: EcABCC8 codes for an efflux pump that 'extrudes' the herbicide glyphosate out of a cell's cytoplasm, making Echinochloa colona ('awnless barnyardgrass') glyphosate resistant.
 traits:
+  - entity_name: glyphosate sensitivity
+    entity: TO:0005006
   - entity_name: herbicide resistance
     entity: OMIT:0025284
   - entity_name: ABC-type transporter activity

--- a/Glycine/max/wip_marlene/Pan_Yu_2021
+++ b/Glycine/max/wip_marlene/Pan_Yu_2021
@@ -2,7 +2,7 @@ gene_symbols:
   - EcABCC8
 gene_symbol_long: Echinocloa colona ATP-binding cassette transporter
 gene_model_pub_name: MT249005
-gene_model_full_id: MT249005
+gene_model_full_id: ~
 confidence: 5
 comments: 
   - Overexpression of EcABCC8 (or its orthologs) in transgenic plants created glyphosate resistance. EcABCC8 knockout plants had decreased resistance to glyphosate.

--- a/Glycine/max/wip_marlene/Pan_Yu_2021
+++ b/Glycine/max/wip_marlene/Pan_Yu_2021
@@ -1,12 +1,12 @@
 gene_symbols:
-  - EcABCC8
-gene_symbol_long: Echinocloa colona ATP-binding cassette transporter
-gene_model_pub_name: MT249005
-gene_model_full_id: ~
+  - GmABCC8
+gene_symbol_long: Glycine max ATP-binding cassette transporter
+gene_model_pub_name: Glyma.07G011600.1
+gene_model_full_id: glyma.Wm82.gnm2.ann1.Glyma.07G011600 
 confidence: 5
 comments: 
-  - Overexpression of EcABCC8 (or its orthologs) in transgenic plants created glyphosate resistance. EcABCC8 knockout plants had decreased resistance to glyphosate.
-phenotype_synopsis: EcABCC8 codes for an efflux pump that 'extrudes' the herbicide glyphosate out of a cell's cytoplasm, making Echinochloa colona ('awnless barnyardgrass') glyphosate resistant.
+  - Overexpression of GmABCC8 in transgenic plants created glyphosate resistance. GmABCC8 knockout plants had decreased resistance to glyphosate.
+phenotype_synopsis: GmABCC8 codes for an efflux pump that 'extrudes' the herbicide glyphosate out of a cell's cytoplasm, making the plant glyphosate resistant.
 traits:
   - entity_name: glyphosate sensitivity
     entity: TO:0005006


### PR DESCRIPTION
Pan L, Yu Q, Wang J, Han H, Mao L, Nyporko A, Maguza A, Fan L, Bai L, Powles S. An ABCC-type transporter endowing glyphosate resistance in plants. Proc Natl Acad Sci U S A. 2021 Apr 20;118(16):e2100136118. doi: 10.1073/pnas.2100136118. PMID: 33846264; PMCID: PMC8072331.
I didn't find an ontology tag for glyphosate resistance, so I labeled it under 'herbicide resistance.'