### PR TITLE
Revisions to Redekar_Glover_2020.yml on 18 March 2024

### DIFF
--- a/Glycine/max/studies/Redekar_Glover_2020.yml
+++ b/Glycine/max/studies/Redekar_Glover_2020.yml
@@ -1,8 +1,7 @@
 ---
 gene_symbols:
   - GmMIPS
-  - GmMIPS1
-gene_symbol_long: Myo-Inositol-3-Phosphate Synthase
+gene_symbol_long: Myo-Inositol-Phosphate Synthase
 gene_model_pub_name: Glyma.11G238800
 gene_model_full_id: glyma.Wm82.gnm2.ann1.Glyma.11G238800
 confidence: 3
@@ -10,8 +9,8 @@ curators:
   - Marlene Dorneich-Hayes
   - Scott Kalberer
 comments:
-  - Silencing of MIPS in transgenic lines (with RNAi and antisense) reduces accumulation of phytic acid in seeds.
-phenotype_synopsis: MIPS codes for the rate-limiting enzyme in phytic acid biosynthesis. Supression of MIPS reduces the phytic acid concentration in seeds which improves their nutritional value, but also reduces their germination rate.
+  - Silencing of GmMIPS in transgenic lines (with RNAi and antisense) reduces accumulation of phytic acid in seeds.
+phenotype_synopsis: GmMIPS codes for the rate-limiting enzyme in phytic acid biosynthesis. Supression of MIPS reduces the phytic acid concentration in seeds which improves their nutritional value, but also reduces their germination rate.
 traits:
   - entity_name: biosynthetic process
     entity: GO:0009058

--- a/Glycine/max/studies/Redekar_Glover_2020.yml
+++ b/Glycine/max/studies/Redekar_Glover_2020.yml
@@ -1,29 +1,33 @@
 ---
 gene_symbols:
+  - GmMIPS
   - GmMIPS1
-gene_symbol_long: Myo-Inositol-3-Phosphate Synthase 1
+gene_symbol_long: Myo-Inositol-3-Phosphate Synthase
 gene_model_pub_name: Glyma.11G238800
 gene_model_full_id: glyma.Wm82.gnm2.ann1.Glyma.11G238800
 confidence: 3
+curators:
+  - Marlene Dorneich-Hayes
+  - Scott Kalberer
 comments:
-  - Silencing of MIPS1 in transgenic lines (with RNAi and antisense) reduces accumulation of phytic acid in seeds.
-phenotype_synopsis: MIPS1 codes for the rate-limiting enzyme in phytic acid biosynthesis. Supression of MIPS1 reduces the phytic acid concentration in seeds which improves their nutritional value, but also reduces their germination rate.
+  - Silencing of MIPS in transgenic lines (with RNAi and antisense) reduces accumulation of phytic acid in seeds.
+phenotype_synopsis: MIPS codes for the rate-limiting enzyme in phytic acid biosynthesis. Supression of MIPS reduces the phytic acid concentration in seeds which improves their nutritional value, but also reduces their germination rate.
 traits:
   - entity_name: biosynthetic process
     entity: GO:0009058
 references:
-  - citation: Redekar, Glover et. al., 2020
+  - citation: Redekar, Glover et al., 2020
     doi: 10.1371/journal.pone.0235120
     pmid: 32584851
-  - citation: Kumar, Kumar et. al, 2019
+  - citation: Kumar, Kumar et al., 2019
     doi: 10.1038/s41598-019-44255-7
     pmid: 31123331
-  - citation: Yu, Jin et. al., 2019
+  - citation: Yu, Jin et al., 2019
     doi: 10.1186/s12870-019-2201-4
     pmid: 31856712
-  - citation: Nunes, Vianna et. al., 2006
+  - citation: Nunes, Vianna et al., 2006
     doi: 10.1007/s00425-005-0201-0
     pmid: 16395584
-  - citation: Hegeman, Good et. al., 2001
+  - citation: Hegeman, Good et al., 2001
     doi: 10.1104/pp.125.4.1941
     pmid: 11299373


### PR DESCRIPTION
I corrected the gene symbols, gene_symbol_long, comments, and phenotype_synopsis lines so as to have one gene symbol (GmMIPS) with Genus-species prefix and no numerical suffix.  Please review alterations and then merge to the main branch.