### PR TITLE
Revisions to pissa.Sato_Morita_2007.yml on 18 April 2024

### DIFF
--- a/Pisum/sativum/studies/pissa.Sato_Morita_2007.yml
+++ b/Pisum/sativum/studies/pissa.Sato_Morita_2007.yml
@@ -1,7 +1,6 @@
 ---
 scientific_name: Pisum sativum
-classical_locus:
-  - I
+classical_locus: I
 gene_symbols:
   - PsSGR
 gene_symbol_long: Staygreen
@@ -12,24 +11,31 @@ curators:
   - Marlene Dorneich-Hayes
   - Scott Kalberer
 comments:
-  - Complementation test confirms that SGR is Mendel's I locus. SGR is a positive regulator of pathways involved in breakdown of
-    chlorophyll via translational or posttranslational regulation of chlorophyll degrading enzymes. The products of SGR are required
+  - Complementation test confirms that PsSGR is the Mendelian I locus. SGR is a positive regulator of pathways involved in breakdown of
+    chlorophyll via translational or post-translational regulation of chlorophyll degrading enzymes. The products of SGR are required
     to separate chlorophyll from the photosynthetic complex, allowing chlorophyll degrading enzymes access to their substrate.
     The sgr loss-of-function mutation is due to lower expression of the SGR gene and a small insertion that disrupts SGR protein fuction.
-phenotype_synopsis: The recessive phenotype sgr retains a high chlorophyll content during scenesence, causing cotyledons to stay green as
+phenotype_synopsis: The recessive phenotype sgr retains a high chlorophyll content during senescence, causing cotyledons to stay green as
     they mature and leaves to stay green as they die. PsSGR is a cosmetic stay-green mutant and does not retain the ability to photosynthesize.
 traits:
-  - entity_name:
-    entity:
+  - entity_name: chlorophyll catabolic process
+    entity: GO:0015996
+  - entity_name: positive regulation of chlorophyll catabolic process
+    entity: GO:1903648
+  - entity_name: plant embryo cotyledon color
+    entity: TO:0000980
+  - entity_name: leaf senescence trait
+    entity: TO:0000249
 references:
-  - citation: Sato, Morita et. al., 2007
+  - citation: Sato, Morita et al., 2007
     doi: 10.1073/pnas.0705521104
     pmid: 17709752
-  - citation: Armstead, Donnison et. al., 2007
+  - citation: Armstead, Donnison et al., 2007
     doi: 10.1126/science.1132912
     pmid: 17204643
-  - citation: Aubry, Mani et. al., 2008
+  - citation: Aubry, Mani et al., 2008
     doi: 10.1007/s11103-008-9314-8
     pmid: 18301989
   - citation: Hörtensteiner, 2009
     doi: 10.1016/j.tplants.2009.01.002
+    pmid: 19237309


### PR DESCRIPTION
I've corrected the gene_function_registry file pissa.Sato_Morita_2007.yml originally created by Marlena Dorneich-Hayes. I created the new branch pissa.Sato_Morita_2007 with this revised file and pushed it up to the GitHub origin. I'm requesting review of this YML gene function file, merge of the changes into main branch, and subsequent deletion of this temporary branch on GitHub.