### PR TITLE
Revisions to glyma.Bai_Jing_2021.yml and renaming to glyma.Bai_Jing_2020.yml on 23 April 2024

### DIFF
--- a/Glycine/max/studies/glyma.Bai_Jing_2020.yml
+++ b/Glycine/max/studies/glyma.Bai_Jing_2020.yml
@@ -9,7 +9,7 @@ confidence: 5
 curators:
   - Greg Murrell
   - Scott Kalberer
-phenotype_summary: Overexpression of GmPLDγ from soybean results in higher seed oil content and fatty-acid remodeling in Arabidopsis.
+phenotype_summary: Overexpression of GmPLDγ introduced from soybean results in higher seed oil content and fatty-acid remodeling in Arabidopsis.
 traits:
   - entity_name: seed oil content
     entity: CO_336:0000048
@@ -26,7 +26,7 @@ traits:
   - relation_name: positively regulates
     relation: RO:0002213
 references:
-  - citation: Bai, Jing et al., 2021
+  - citation: Bai, Jing et al., 2020
     doi: 10.1016/j.plantsci.2019.110298
     pmid: 31779909
 

--- a/Glycine/max/studies/glyma.Bai_Jing_2021.yml
+++ b/Glycine/max/studies/glyma.Bai_Jing_2021.yml
@@ -2,12 +2,13 @@
 scientific_name: Glycine max
 gene_symbols:
   - GmPLDγ
-gene_symbol_long: Phospholipase D
-gene_model_pub_name: Glyma.01g42420
-gene_model_full_id: Glyma.Wm82.gmn1.Glyma01g42420
+gene_symbol_long: Phospholipase D gamma
+gene_model_pub_name: Glyma.01G215100
+gene_model_full_id: glyma.Wm82.gnm2.ann1.Glyma.01G215100
 confidence: 5
 curators:
   - Greg Murrell
+  - Scott Kalberer
 phenotype_summary: Overexpression of GmPLDγ from soybean results in higher seed oil content and fatty-acid remodeling in Arabidopsis.
 traits:
   - entity_name: seed oil content


### PR DESCRIPTION
Produced a revised version of the gene_function_registry file glyma.Bai_Jing_2020.yml that's new and improved.  Corrections include the issue requested as "Incorrect gene_model_pub_name name in Glycine/max/studies/glyma.Bai_Jing_2021.yml #38".  Finally, I renamed the file to glyma.Bai_Jing_2020.yml based on the correct date of print publication in 2020 (a corrigendum for figure 4c was published in 2021).  I created the new branch glyma.Bai_Jing_2020 with this revised file and pushed it up to the GitHub origin. I'm requesting review of this YML gene function file, merge of the changes into main branch, and subsequent deletion of this temporary branch on GitHub.