### PR TITLE
Revisions to lotja.Soyano_Hirakawa_2014.yml on 30 August 2024

### DIFF
--- a/Lotus/japonicus/studies/lotja.Soyano_Hirakawa_2014.yml
+++ b/Lotus/japonicus/studies/lotja.Soyano_Hirakawa_2014.yml
@@ -2,15 +2,16 @@
 scientific_name: Lotus japonicus
 gene_symbols:
   - LjNIN
-gene_symbol_long: Nodule INception
+gene_symbol_long: Nodule Inception
 gene_model_pub_name: Lj2g3v3373110
 gene_model_full_id: lotja.MG20.gnm3.ann1.Lj2g3v3373110
 confidence: 4
 curators:
   - Marlene Dorneich-Hayes
+  - Scott Kalberer
 comments:
-  - Ectopic expression of NIN produces extra nodule-like structures but, in the presence of nitrate, downregulates genes needed to establish symbiosis. Constitutive expression of NIN eventually leads to suppression of NIN and stops further nodulation.
-phenotype_synopsis: NIN is part of a negative feedback loop. It codes for a transcription factor which induces nodulation by promoting cortical cell division, but also activates genes which code for the NIN-repressing signal proteins CLE-RS1 and CLE-RS2 which stop nodulation. NIN positively regulates rhizobium infection by inducing the genes necessary to establish symbiosis in the absence of nitrate.
+  - Ectopic expression of LjNIN produces extra nodule-like structures but, in the presence of nitrate, downregulates genes needed to establish symbiosis. Constitutive expression of NIN eventually leads to suppression of NIN and stops further nodulation.
+phenotype_synopsis: LjNIN is part of a negative feedback loop. It codes for a transcription factor which induces nodulation by promoting cortical cell division, but also activates genes which code for the NIN-repressing signal proteins CLE-RS1 and CLE-RS2 which stop nodulation. NIN positively regulates rhizobium infection by inducing the genes necessary to establish symbiosis in the absence of nitrate.
 traits:
   - entity_name: regulation of biological process involved in symbiotic interaction
     entity: GO:0043903
@@ -21,14 +22,15 @@ traits:
   - relation_name: negatively regulates
     relation: RO:0002212
 references:
-  - citation: Soyano, Hirakawa et. al., 2014
+  - citation: Soyano, Hirakawa et al., 2014
     doi: 10.1073/pnas.1412716111
     pmid: 25246578
-  - citation: Soyano, Shimoda et. al., 2015
+  - citation: Soyano, Shimoda et al., 2015
     doi: 10.1093/pcp/pcu168
     pmid: 25416287
-  - citation: Yoro, Suzaki et. al., 2014
+  - citation: Yoro, Suzaki et al., 2014
     doi: 10.1104/pp.113.233379
     pmid: 24722550
-  - citation: Nishida, Nosaki et. al., 2021
-    doi: doi.org/10.1093/plcell/koab103
+  - citation: Nishida, Nosaki et al., 2021
+    doi: 10.1093/plcell/koab103
+    pmid: 33826745

--- a/Lotus/japonicus/studies/lotja.Soyano_Hirakawa_2014.yml
+++ b/Lotus/japonicus/studies/lotja.Soyano_Hirakawa_2014.yml
@@ -10,10 +10,24 @@ curators:
   - Marlene Dorneich-Hayes
   - Scott Kalberer
 comments:
-  - Ectopic expression of Nodule Inception (LjNIN) produces nodule-like structures from the roots regardless of lack of rhizobia. Constitutive expression of NIN eventually leads to suppression of native NIN transcription in untransformed roots of the plant via effects on HAR1 receptor protein. The result is reduced nodulation and down-regulation of CLE-RS signal peptide expression.
-  - NIN codes for a transcription factor containing the RWP-RK domain that induces nodule primordia formation by promoting cortical cell division.
-  - NIN activates genes coding for the NIN-repressing signal proteins, Clavata3/Endosperm Surrounding Region Root Signal 1 (CLE-RS1) and CLE-RS2, that are expressed in the roots and travel long-distance to ultimately stop nodulation. They are perceived in the shoot by Hypernodulation Aberrant Root Formation 1 (HAR1) receptor proteins.
-phenotype_synopsis: LjNIN is part of an autoregulatory negative feedback loop in Lotus japonicus that maintains healthy numbers of nodules containing nitrogen-fixing rhizobia. NIN positively regulates rhizobium infection by inducing the genes necessary to establish the symbiosis when nitrate is limited.
+  - Ectopic expression of Nodule Inception (LjNIN) produces nodule-like
+    structures from the roots regardless of lack of rhizobia. Constitutive
+    expression of NIN eventually leads to suppression of native NIN
+    transcription in untransformed roots of the plant via effects on HAR1
+    receptor protein. The result is reduced nodulation and down-regulation of
+    CLE-RS signal peptide expression.
+  - NIN codes for a transcription factor containing the RWP-RK domain that
+    induces nodule primordia formation by promoting cortical cell division.
+  - NIN activates genes coding for the NIN-repressing signal proteins,
+    Clavata3/Endosperm Surrounding Region Root Signal 1 (CLE-RS1) and CLE-RS2,
+    that are expressed in the roots and travel long-distance to ultimately stop
+    nodulation. They are perceived in the shoot by Hypernodulation Aberrant Root
+    Formation 1 (HAR1) receptor proteins.
+phenotype_synopsis: LjNIN is part of an autoregulatory negative feedback loop in
+  Lotus japonicus that maintains healthy numbers of nodules containing
+  nitrogen-fixing rhizobia. NIN positively regulates rhizobium infection by
+  inducing the genes necessary to establish the symbiosis when nitrate is
+  limited.
 traits:
   - entity_name: regulation of biological process involved in symbiotic interaction
     entity: GO:0043903

--- a/Lotus/japonicus/studies/lotja.Soyano_Hirakawa_2014.yml
+++ b/Lotus/japonicus/studies/lotja.Soyano_Hirakawa_2014.yml
@@ -3,24 +3,26 @@ scientific_name: Lotus japonicus
 gene_symbols:
   - LjNIN
 gene_symbol_long: Nodule Inception
-gene_model_pub_name: Lj2g3v3373110
-gene_model_full_id: lotja.MG20.gnm3.ann1.Lj2g3v3373110
+gene_model_pub_name: Lj2G3V3373110
+gene_model_full_id: lotja.MG20.gnm3.ann1.Lj2G3V3373110
 confidence: 4
 curators:
   - Marlene Dorneich-Hayes
   - Scott Kalberer
 comments:
-  - Ectopic expression of LjNIN produces extra nodule-like structures but, in the presence of nitrate, downregulates genes needed to establish symbiosis. Constitutive expression of NIN eventually leads to suppression of NIN and stops further nodulation.
-phenotype_synopsis: LjNIN is part of a negative feedback loop. It codes for a transcription factor which induces nodulation by promoting cortical cell division, but also activates genes which code for the NIN-repressing signal proteins CLE-RS1 and CLE-RS2 which stop nodulation. NIN positively regulates rhizobium infection by inducing the genes necessary to establish symbiosis in the absence of nitrate.
+  - Ectopic expression of Nodule Inception (LjNIN) produces nodule-like structures from the roots regardless of lack of rhizobia. Constitutive expression of NIN eventually leads to suppression of native NIN transcription in untransformed roots of the plant via effects on HAR1 receptor protein. The result is reduced nodulation and down-regulation of CLE-RS signal peptide expression.
+  - NIN codes for a transcription factor containing the RWP-RK domain that induces nodule primordia formation by promoting cortical cell division.
+  - NIN activates genes coding for the NIN-repressing signal proteins, Clavata3/Endosperm Surrounding Region Root Signal 1 (CLE-RS1) and CLE-RS2, that are expressed in the roots and travel long-distance to ultimately stop nodulation. They are perceived in the shoot by Hypernodulation Aberrant Root Formation 1 (HAR1) receptor proteins.
+phenotype_synopsis: LjNIN is part of an autoregulatory negative feedback loop in Lotus japonicus that maintains healthy numbers of nodules containing nitrogen-fixing rhizobia. NIN positively regulates rhizobium infection by inducing the genes necessary to establish the symbiosis when nitrate is limited.
 traits:
   - entity_name: regulation of biological process involved in symbiotic interaction
     entity: GO:0043903
-  - relation_name: positively regulates
-    relation: RO:0002213
-  - entity_name: nodulation
-    entity: GO:0009877
   - relation_name: negatively regulates
     relation: RO:0002212
+  - entity_name: nodulation
+    entity: GO:0009877
+  - relation_name: positively regulates
+    relation: RO:0002213
 references:
   - citation: Soyano, Hirakawa et al., 2014
     doi: 10.1073/pnas.1412716111


### PR DESCRIPTION
I've corrected the Lotus japonicus gene_function_registry file lotja.Soyano_Hirakawa_2014.yml originally created by Marlena Dorneich-Hayes. I created the new branch lotja.Soyano_Hirakawa_2014 with this revised file and pushed it up to the GitHub origin. I'm requesting review of this YML gene function file, merge of the changes into main branch, and subsequent deletion of this temporary branch on GitHub.