### PR TITLE
Medtr.botkin farmer 2024

### DIFF
--- a/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
+++ b/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
@@ -1,21 +1,49 @@
 ---
 scientific_name: Medicago truncatula
 gene_symbols:
-  - Mtrnpm1
-gene_symbol_long: Resistance to the necrotroph Phoma medicaginis 1
-gene_model_pub_name: MtrunA17_Chr4g0009401
-gene_model_full_id:
-confidence:
+  - MtGST
+gene_symbol_long: glutathione S-transferase
+gene_model_pub_name: MtrunA17_Chr4g0008781
+gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0008781
+confidence: 5
 curators:
   - Raegan Nelson
 comments:
-  -MYB, MADS-box, C2H2, TIR-NBS-LRR gene clusters and B3-domain transcription factors were identified in rnpm1
-  -Glutathione S-transferase (GST) and a B3-domain transcription factor as candidate genes for SBS disease resistance
-  -a frameshift resulted in a downstream premature stop codon in the HM078 homolog caused a loss-of-function in a TIR-NBS-LRR gene
-phenotype_synopsis: Mtrnpm1 regulates spring black stem and leaf spot disease resistance
+  -Glutathione S-transferase (GST) is a candidate gene for SBS disease resistance in rpm1
+  -GSTs participate in detoxification of xenobiotic toxins, reduction of oxidative stress, and are receptors of salicylic acid
+  -In HM078, the GST contained a 12 bp insertion in the 5’ UTR region, which is known to contain microRNA binding sites and structural features that regulate mRNA splicing and stability
+phenotype_synopsis: MtGST detoxifys toxic substances in plants and reduces oxidative stress in Medicago
 traits:
-  - entity_name: 
-    entity:
+  - entity_name: positive regulation of cellular response to oxidative stress 
+    entity: GO:1900409
+  - entity_name: xenobiotic detoxification by transmembrane export across the plasma membrane
+    entity: GO:1990961
+references:
+  - citation: Botkin, Farmer,et al.2024
+    doi: 10.1186/s12864-024-10112-9
+    pmid: 38395768
+  - citation: Gullner, Komives,et al.2018
+    doi: 10.3389/fpls.2018.01836
+    pmid: 30622544
+---
+scientific_name: Medicago truncatula
+gene_symbols:
+  - 
+gene_symbol_long: TIR-NBS-LRR gene
+gene_model_pub_name: MtrunA17_Chr4g0009401
+gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0009401
+confidence: 5
+curators:
+  - Raegan Nelson
+comments:
+  -A single base pair insertion in the coding region of TIR-NBS-LRR resulted in a frame-shift mutation in the HM078 homolog that produced a downstream premature stop codon
+  -This truncation likely causes a loss-of-function due to the absence of the LRR domain in the predicted peptide
+  -A loss-of-function in the TIR-NBS-LRR gene could alleviate sensitivity to a HST that has yet to be identified
+  -Could be acting as a negative regulator of unidentified plant disease resistance protein
+phenotype_synopsis: TIR-NBS-LRR gene regulates Medicago defense response
+traits:
+  - entity_name: defense response
+    entity: GO:0006952
 references:
   - citation: Botkin, Farmer,et al.2024
     doi: 10.1186/s12864-024-10112-9
@@ -23,21 +51,54 @@ references:
 ---
 scientific_name: Medicago truncatula
 gene_symbols:
-  - Mtrnpm2
-gene_symbol_long: Resistance to the necrotroph Phoma medicaginis 2
-gene_model_pub_name: 
-gene_model_full_id:
-confidence:
+  - MtB3
+gene_symbol_long: B3-domain transcription factor
+gene_model_pub_name: MtrunA17_Chr4g0009491
+gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0009491
+confidence: 5
 curators:
   - Raegan Nelson
 comments:
-  - F-box protein interaction domain protein in rnpm2 contained several missense mutations as well as a frameshift variant causing a truncation in HM078
-  - could be acting as a negative regulator to unidentified plant disease resistance proteins
-phenotype_synopsis: Mtrnpm2 regulates spring black stem and leaf spot disease resistance
+  -B3-domain transcription factor has a single base pair deletion and a two base pair insertion in the HM078 homolog caused a 98 amino acid deletion and truncation of a B3 domain
+  -B3-domain transcription factor is a candidate gene for SBS disease resistance found in rpm1
+  -B3-domain transcription factors are co-expressed during secondary cell walls biosynthesis and lignin formation
+phenotype_synopsis: B3-domain transcription factors regulate lignin and cell wall biosynthesis
 traits:
-  - entity_name:
-    entity:
+  - entity_name: lignin biosynthetic process
+    entity: GO:0009809
+  - entity_name: plant-type secondary cell wall biogenesis
+    entity: GO:0009834
 references:
   - citation: Botkin, Farmer,et al.2024
     doi: 10.1186/s12864-024-10112-9
     pmid: 38395768
+  - citation: Wei, Li,et al.2023
+    doi: 10.3389/fpls.2023.1193065
+    pmid: 37324718
+---
+scientific_name: Medicago truncatula
+gene_symbols:
+  - MtPHO2A
+gene_symbol_long: phosphate 2A
+gene_model_pub_name: MtrunA17_Chr4g0009054
+gene_model_full_id:
+confidence: 5
+curators:
+  - Raegan Nelson
+comments:
+  - A 10.85 kbp insertion in the second coding sequence of PHO2A causes a loss-of-function in HM078s
+  - In M. truncatula, PHO2A was shown to have very low expression compared to the PHO2B and PHO2C paralogs, which have roles in symbiotic nitrogen fixation and Pi homeostasis
+  - PHO2A had the highest expression in shoot tissue during phosphate starvation
+phenotype_synopsis: MtPHO2A regulates Pi homeostatsis and expression in shoot tissue
+traits:
+  - entity_name: cellular response to phosphate starvation
+    entity: GO:0016036
+  - entity_name: phosphate ion homeostasis
+    entity: GO:0055062
+references:
+  - citation: Botkin, Farmer,et al.2024
+    doi: 10.1186/s12864-024-10112-9
+    pmid: 38395768
+  - citation: Huertas, Torres-Jerez,et al.2023
+    doi: 10.3389/fpls.2023.1211107
+    pmid: 37409286

--- a/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
+++ b/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
@@ -14,7 +14,7 @@ comments:
   -In HM078, the GST contained a 12 bp insertion in the 5’ UTR region, which is known to contain microRNA binding sites and structural features that regulate mRNA splicing and stability
 phenotype_synopsis: MtGST detoxifys toxic substances in plants and reduces oxidative stress in Medicago
 traits:
-  - entity_name: positive regulation of cellular response to oxidative stress 
+  - entity_name: positive regulation of cellular response to oxidative stress
     entity: GO:1900409
   - entity_name: xenobiotic detoxification by transmembrane export across the plasma membrane
     entity: GO:1990961
@@ -81,7 +81,7 @@ gene_symbols:
   - MtPHO2A
 gene_symbol_long: phosphate 2A
 gene_model_pub_name: MtrunA17_Chr4g0009054
-gene_model_full_id: N/A
+gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0046981
 confidence: 5
 curators:
   - Raegan Nelson

--- a/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
+++ b/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
@@ -81,7 +81,7 @@ gene_symbols:
   - MtPHO2A
 gene_symbol_long: phosphate 2A
 gene_model_pub_name: MtrunA17_Chr4g0009054
-gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0046981
+gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0009061
 confidence: 5
 curators:
   - Raegan Nelson

--- a/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
+++ b/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
@@ -38,7 +38,7 @@ curators:
 comments:
   -A single base pair insertion in the coding region of TIR-NBS-LRR resulted in a frame-shift mutation in the HM078 homolog that produced a downstream premature stop codon
   -This truncation likely causes a loss-of-function due to the absence of the LRR domain in the predicted peptide
-  -A loss-of-function in the TIR-NBS-LRR gene could alleviate sensitivity to a HST that has yet to be identified
+  -A loss-of-function in the TIR-NBS-LRR gene could alleviate sensitivity to a host sensitive toxin that has yet to be identified
   -Could be acting as a negative regulator of unidentified plant disease resistance protein
 phenotype_synopsis: TIR-NBS-LRR gene regulates Medicago defense response
 traits:
@@ -51,7 +51,7 @@ references:
 ---
 scientific_name: Medicago truncatula
 gene_symbols:
-  - MtB3
+  - 
 gene_symbol_long: B3-domain transcription factor
 gene_model_pub_name: MtrunA17_Chr4g0009491
 gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0009491

--- a/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
+++ b/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
@@ -1,0 +1,43 @@
+---
+scientific_name: Medicago truncatula
+gene_symbols:
+  - Mtrnpm1
+gene_symbol_long: Resistance to the necrotroph Phoma medicaginis 1
+gene_model_pub_name: MtrunA17_Chr4g0009401
+gene_model_full_id:
+confidence:
+curators:
+  - Raegan Nelson
+comments:
+  -MYB, MADS-box, C2H2, TIR-NBS-LRR gene clusters and B3-domain transcription factors were identified in rnpm1
+  -Glutathione S-transferase (GST) and a B3-domain transcription factor as candidate genes for SBS disease resistance
+  -a frameshift resulted in a downstream premature stop codon in the HM078 homolog caused a loss-of-function in a TIR-NBS-LRR gene
+phenotype_synopsis: Mtrnpm1 regulates spring black stem and leaf spot disease resistance
+traits:
+  - entity_name: 
+    entity:
+references:
+  - citation: Botkin, Farmer,et al.2024
+    doi: 10.1186/s12864-024-10112-9
+    pmid: 38395768
+---
+scientific_name: Medicago truncatula
+gene_symbols:
+  - Mtrnpm2
+gene_symbol_long: Resistance to the necrotroph Phoma medicaginis 2
+gene_model_pub_name: 
+gene_model_full_id:
+confidence:
+curators:
+  - Raegan Nelson
+comments:
+  - F-box protein interaction domain protein in rnpm2 contained several missense mutations as well as a frameshift variant causing a truncation in HM078
+  - could be acting as a negative regulator to unidentified plant disease resistance proteins
+phenotype_synopsis: Mtrnpm2 regulates spring black stem and leaf spot disease resistance
+traits:
+  - entity_name:
+    entity:
+references:
+  - citation: Botkin, Farmer,et al.2024
+    doi: 10.1186/s12864-024-10112-9
+    pmid: 38395768

--- a/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
+++ b/Medicago/truncatula/studies/medtr.Botkin_Farmer_2024.yml
@@ -28,7 +28,7 @@ references:
 ---
 scientific_name: Medicago truncatula
 gene_symbols:
-  - 
+  - Mt
 gene_symbol_long: TIR-NBS-LRR gene
 gene_model_pub_name: MtrunA17_Chr4g0009401
 gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0009401
@@ -51,7 +51,7 @@ references:
 ---
 scientific_name: Medicago truncatula
 gene_symbols:
-  - 
+  - Mt
 gene_symbol_long: B3-domain transcription factor
 gene_model_pub_name: MtrunA17_Chr4g0009491
 gene_model_full_id: medtr.A17.gnm5.ann1_6.MtrunA17Chr4g0009491
@@ -81,7 +81,7 @@ gene_symbols:
   - MtPHO2A
 gene_symbol_long: phosphate 2A
 gene_model_pub_name: MtrunA17_Chr4g0009054
-gene_model_full_id:
+gene_model_full_id: N/A
 confidence: 5
 curators:
   - Raegan Nelson


### PR DESCRIPTION
Did the blast search with the PHOA gene sequence, put down the full ID of the gene closest to the PHOA sequence.
B3 and TIR-NBS-LRR genes are left blank as we agreed that a symbol would be assigned to them later on.