### PR TITLE
Shiny New Gene Function File for Violet Locus Encoding Flavonoid 3′,5′-Hydroxylase in Phaseolus vulgaris

### DIFF
--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -11,23 +11,41 @@ curators:
   - Scott Kalberer
 comments:
   - Purple mutants of snap beans (the common bean Phaseolus vulgaris) exhibit
-    purple cotyledons, hypocotyls, stems, leaf veins, flower and pod tissues.
+    purple cotyledons, hypocotyls, stems, leaf veins, flower and pod tissues
+    (Liu, Yang et al., 2023).
   - Levels of total anthocyanins, delphinidins, and malvidins in purple-mutant
-    pods were significantly higher than in wild-type plants.
+    pods were significantly higher than in wild-type plants (Liu, Yang et al.,
+    2023).
+  - The classical V (violet, purple) gene of Phaseolus vulgaris functions within
+    a genetic network that controls seed coat and flower color and flavonoid
+    content (McClean, Lee et al., 2022).
+  - The V locus was mapped to a narrow interval on chromosome Pv06. A candidate
+    gene was selected based on flavonoid analysis and confirmed by
+    recombinational mapping. Protein and domain modeling determined that V
+    encodes the enzyme flavonoid 3′5′ hydroxylase (F3′5′H), a P450 enzyme
+    required for the expression of dihydromyricetin-derived flavonoids in the
+    flavonoid pathway. F3′5′H evolved as a major target gene for the evolution
+    of flower and seed coat color in plants (McClean, Lee et al., 2022).
   - Phvul.006G018800, the candidate gene for Purple Mutation (PvPUR), is
     localized to the 243.9-kb region of chromosome Pv06. The gene encodes the
     enzyme Flavonoid 3',5'-hydroxylase (F3’5’H), a member of the cytochrome P450
     family. F3’5’H converts the dihydroflavonols named dihydrokaempferol (DHK)
     and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of the
     blue-to-red pH-sensitive plant pigment delphinidin and its anthocyanin
-    derivatives.
+    derivatives (Liu, Yang et al., 2023).
+  - Eight recessive haplotypes of the V locus, defined by mutations of key
+    functional domains required for P450 activities, evolved independently in
+    the two bean gene pools from a common ancestral gene (McClean, Lee et al.,
+    2022).
   - Six single-base mutations within the coding region of PvPUR altered the
-    protein structure of F3’5’H resulting in the purple phenotype.
+    protein structure of F3’5’H resulting in the purple phenotype (Liu, Yang et
+    al., 2023).
   - To validate the candidate gene's function, Arabidopsis thaliana were
     transformed using wild-type and purple-mutant common bean alleles. Compared
     with the wild-type Arabidopsis, the leaf bases and internodes of plants
     receiving the purple-mutant allele were purple, whereas the phenotypes of
-    Arabidopsis transformed with the wild-type allele remained unaffected.
+    Arabidopsis transformed with the wild-type allele remained unaffected (Liu,
+    Yang et al., 2023).
 phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
   biosynthesis in common bean and results in purple coloration of many tissues.
 traits:

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -2,8 +2,9 @@
 scientific_name: Phaseolus vulgaris
 classical_locus: V
 gene_symbols:
+  - PvV
   - PvPUR
-gene_symbol_long: Purple Mutation
+gene_symbol_long: Violet
 gene_model_pub_name: Phvul.006G018800
 gene_model_full_id: phavu.G19833.gnm2.ann1.Phvul.006G018800
 confidence: 5
@@ -47,20 +48,25 @@ comments:
     screened genotypes. Eight recessive haplotypes of the V locus that control
     pink or white flower color, defined by mutations of key functional domains
     required for P450 activities, evolved independently in the two bean gene
-    pools from a common ancestral gene. The white v[Mex235] haplotype was
-    discovered in both Andean and Mesoamerican gene pools indicating its early
-    appearance. The other haplotypes were gene pool-specific, including the
-    v-lae pink-flowered haplotypes in the Andean gene pool (McClean, Lee et al.,
-    2022).
-  - Evidence that V encodes F3′5′H was provided by the discovery of the v-lae
-    [M0056] white-flowering haplotype. M0056 was produced by a natural
-    intragenic recombination event between the v-lae [MDRK] (pink flower) and v
-    [Mex235] (white flower) haplotypes. A deletion introduced to the v-lae [MDRK]
-    haplotype resulted in a frame-shift stop codon that eliminated the essential
-    heme-binding and SRS6 regions. This recombination event is a natural
-    equivalent to gene editing in a species, P. vulgaris, in which such
-    complementation technologies have yet to be developed (McClean, Lee et al.,
-    2022).
+    pools from a common ancestral dominant haplotype V-[5-593]. V-[5-593]
+    expression caused purple flowers in both Middle American and Andean gene
+    pools. The white v-[Mex235] haplotype was discovered in both Andean and
+    Mesoamerican gene pools indicating its early appearance. The other
+    haplotypes were gene pool-specific, including the v-lae pink-flowered
+    haplotypes in the Andean gene pool (McClean, Lee et al., 2022).
+  - Definitive evidence that V encodes F3′5′H was provided by the discovery of
+    the v-[M0056] white-flowering haplotype. This v-[M0056] was produced by a
+    natural intragenic crossover event between the v-lae[MDRK] (pink flower) and
+    v-[Mex235] (white flower) haplotypes. The 14-nt deletion within the
+    v-[Mex235] chromosome resulted in a frame-shift stop codon that eliminated
+    the heme-binding domain and SRS6 regions of F3'5'H. The v-[M0056]
+    recombinant haplotype contains the 5′-end of v-lae[MDRK] alongside the
+    3′-end of v-[Mex235] that removed F3'5'H functionality. Experimentally, if a
+    section of a candidate gene were to be deleted and a phenotypic change
+    observed, one would conclude that the candidate gene was validated. This
+    recombination event is a natural equivalent to gene editing in a species, P.
+    vulgaris, in which complementation technologies have yet to be developed
+    (McClean, Lee et al., 2022).
   - Purple mutants of snap beans (Phaseolus vulgaris) exhibited purple
     cotyledons, hypocotyls, stems, leaf veins, flower and pod tissues (Liu, Yang
     et al., 2023). Levels of total anthocyanins, delphinidins, and malvidins in

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -11,14 +11,12 @@ confidence: 5
 curators:
   - Scott Kalberer
 comments:
-  - The classical V (violet, purple) locus of Phaseolus vulgaris functions as
-    part of a genetic system that controls colors of seed coats and flowers.
+  - The classical V (Violet, Purple) locus of Phaseolus vulgaris affects the colors of seed coats and flowers.
     Plants with the dominant V allele are purple-flowered whereas homozygous
     recessive plants exhibit white (v) or pink (v-lae) flowers. The dominant V
-    allele is associated with black-seeded beans in the presence of dominant B
-    and G alleles, even as recessive v alleles produce seeds without
+    allele is associated with black-seeded beans, even as recessive v alleles produce seeds without
     dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
-  - Solely genotypes carrying the dominant V allele were found to produce the
+  - Solely genotypes carrying the dominant V allele produced the
     anthocyanin named delphinidin 3-O-glucoside in seed coats. The colors of
     these lines ranged from blue to black (Beninger and Hosfield, 2003).
   - Phytochemical analysis showed that dihydromyricetin-related compounds
@@ -26,31 +24,29 @@ comments:
     from introgression lines with recessive v alleles, greatly reduced in seed
     coats of pink-flowered v-lae lines, and absent in the seed coats of
     white-flowered v lines. The purple-flowered V dominant-allele lines had
-    flowers and seeds containing these compounds known to require synthesis by
-    the active Flavonoid 3′5’Hydroxylase (F3′5′H) enzyme (McClean, Lee et al.,
-    2022).
+    flowers and seeds containing these compounds (McClean, Lee et al., 2022).
   - McClean, Lee et al. (2022) physically mapped the V locus to a narrow
-    interval surrounding a F3′5′H candidate gene model (Phvul.006G018800) on
+    interval surrounding a Flavonoid 3′5’Hydroxylase (F3′5′H) candidate gene model (Phvul.006G018800) on
     chromosome Pv06. This low recombination heterochromoatic region resisted
     fine-mapping and the RAPD marker OD12-800 and 15 indels all co-segregated
     with V. Knowing the V locus to be associated with F3′5′H, a search for gene
     models including the F3′5′H KEGG identifier K13083 within the suspected Pv06
     region of the reference genome G19833 revealed the gene model
     Phvul.006G018800.
-  - Additionally, Garcia-Fernandez, Campa et al. (2021) mapped a ‘TU’ × ‘Musica’
+  - Garcia-Fernandez, Campa et al. (2021) mapped a ‘TU’ × ‘Musica’
     RIL population and showed that one of two genes responsible for a black seed
     coat phenotype was localized to a Pv06 region associated with locus V. They
     also proposed Phvul.006G018800 as the candidate V gene. Yet another study
     found Phvul.006G018800, the candidate gene for a Purple Mutation (PvPUR),
     was localized to the 243.9-kb region of Pv06 (Liu, Yang et al., 2023).
   - Protein and domain modeling determined the V gene encodes the enzyme
-    Flavonoid 3′,5′-Hydroxylase (F3′5′H), a member of the cytochrome P450 family
+    Flavonoid 3′,5′-Hydroxylase (F3′5′H), a member of the Cytochrome P450 family
     (McClean, Lee et al., 2022). Sequence analysis of Phvul.006G018800 protein
-    identified six conserved substrate recognition sites (SRS) and the four
+    identified six conserved substrate recognition sites (SRS) and four
     functional motifs typical of Cytochrome P enzymes. Almost all these domain
     sequences were nearly the same as the functional F3′5′H domains of other
     legumes.
-  - F3'5'H is is required for the expression of dihydromyricetin-derived
+  - Active F3'5'H is required for biosynthesis of dihydromyricetin-derived
     flavonoids (McClean, Lee et al., 2022). Specifically, F3’5’H converts the
     dihydroflavonols named dihydrokaempferol (DHK) and dihydroquercetin (DHQ) to
     dihydromyricetin (DHM), a precursor of the blue-to-red pH-sensitive plant
@@ -61,10 +57,10 @@ comments:
     genotypes. Eight recessive haplotypes that control pink or white flower
     color, defined by mutations of functional domains required for P450
     activities, evolved independently in the two bean gene pools from a common
-    ancestral dominant haplotype V-[5-593]. V-[5-593] expression was connected
-    to purple flowers in Middle American and Andean gene pools. The white
-    v-[Mex235] haplotype was discovered in both Andean and Mesoamerican gene
-    pools indicating its early emergence. The other haplotypes were gene
+    ancestral haplotype V-[5-593]. Dominant V-[5-593] expression was connected
+    to purple flowers in Mesoamerican and Andean gene pools. The white
+    v-[Mex235] haplotype was discovered in both gene
+    pools indicating its early emergence. Other haplotypes were gene
     pool-specific, including the v-lae pink-flowered haplotypes in the Andean
     gene pool (McClean, Lee et al., 2022).
   - Definitive evidence that V encodes F3′5′H was provided by discovery of the
@@ -116,12 +112,12 @@ references:
   - citation: Liu, Yang et al., 2023
     doi: 10.1007/s11032-023-01362-8
     pmid: 37313298
-  - citation: Liu, Yang et al., 2022
-    doi: 10.3390/ijms23031265
-    pmid: 35163188
   - citation: Garcia-Fernandez, Campa et al., 2021
     doi: 10.1007/s00122-021-03922-y
     pmid: 34328529
   - citation: Beninger, Hosfield, 2003
     doi: 10.1021/jf0304324
     pmid: 14690368
+  - citation: McClean, Lee et al., 2002
+    doi: 10.1093/jhered/93.2.148
+    pmid: 12140276

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -19,6 +19,9 @@ comments:
   - The classical V (violet, purple) gene of Phaseolus vulgaris functions within
     a genetic network that controls seed coat and flower color and flavonoid
     content (McClean, Lee et al., 2022).
+  - Solely genotypes carrying the dominant V allele were found to produce the
+    anthocyanin named delphinidin 3-O-glucoside in seed coats. These color of
+    these lines were blue to black in color (Beninger and Hosfield, 2003).
   - The V locus was mapped to a narrow interval on chromosome Pv06. A candidate
     gene was selected based on flavonoid analysis and confirmed by
     recombinational mapping. Protein and domain modeling determined that V
@@ -38,16 +41,16 @@ comments:
     the two bean gene pools from a common ancestral gene (McClean, Lee et al.,
     2022).
   - Evidence that V encodes F3′5′H was provided by the discovery of the vlae
-  [M0056] white-flowering haplotype. M0056 was produced by a natural intragenic
-  recombination event between the vlae [MDRK] (pink flower) and v [Mex235]
-  (white flower) haplotypes. A deletion was introduced to the vlae [MDRK]
-  haplotype, resulting in a frame-shift stop codon that eliminated the essential
-  heme-binding and SRS6 regions. This recombination event is a natural
-  equivalent to gene editing in a species, P. vulgaris, in which such
-  complementation technologies have yet to be developed. When a section of the
-  candidate gene is deleted, and the resultant progeny shows a phenotypic
-  change, the candidate gene is revealed as the causative gene for the phenotype
-  (McClean, Lee et al., 2022).
+    [M0056] white-flowering haplotype. M0056 was produced by a natural
+    intragenic recombination event between the vlae [MDRK] (pink flower) and v
+    [Mex235] (white flower) haplotypes. A deletion was introduced to the vlae
+    [MDRK] haplotype, resulting in a frame-shift stop codon that eliminated the
+    essential heme-binding and SRS6 regions. This recombination event is a
+    natural equivalent to gene editing in a species, P. vulgaris, in which such
+    complementation technologies have yet to be developed. When a section of the
+    candidate gene is deleted, and the resultant progeny shows a phenotypic
+    change, the candidate gene is revealed as the causative gene for the
+    phenotype (McClean, Lee et al., 2022).
   - Six single-base mutations within the coding region of PvPUR altered the
     protein structure of F3’5’H resulting in the purple phenotype (Liu, Yang et
     al., 2023).
@@ -72,3 +75,9 @@ references:
   - citation: Liu, Yang et al., 2022
     doi: 10.3390/ijms23031265
     pmid: 35163188
+  - citation: Garcia-Fernandez, Campa et al., 2021
+    doi: 10.1007/s00122-021-03922-y
+    pmid: 34328529
+  - citation: Beninger, Hosfield, 2003
+    doi: 10.1021/jf0304324
+    pmid: 14690368

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -54,12 +54,20 @@ comments:
     Specifically, F3’5’H converts the dihydroflavonols named dihydrokaempferol
     (DHK) and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of
     the blue-to-red pH-sensitive plant pigment delphinidin and its anthocyanin
-    derivatives (Liu, Yang et al., 2023).
+    derivatives such as delphinidin 3-O-glucoside (Liu, Yang et al., 2023).
 phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
   biosynthesis in common bean and results in purple coloration of many tissues.
 traits:
+  - entity_name: flavonoid content
+    entity: TO:0000290
   - entity_name: anthocyanin content
     entity: TO:0000071
+  - entity_name: seed coat color
+    entity: TO:0000190
+  - entity_name: flower color
+    entity: TO:0000537
+  - entity_name: pericarp color
+    entity: TO:0000707
 references:
   - citation: McClean, Lee et al., 2022
     doi: 10.3389/fpls.2022.869582

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -43,13 +43,15 @@ comments:
     candidate V gene. Yet another study found Phvul.006G018800, now the
     candidate gene for Purple Mutation (PvPUR), was localized to the 243.9-kb
     region of Pv06 (Liu, Yang et al., 2023).
-  - Eight recessive haplotypes of the V locus that control pink or white flower
-    color, defined by mutations of key functional domains required for P450
-    activities, evolved independently in the two bean gene pools from a common
-    ancestral gene. The white v[Mex235] haplotype was discovered in both Andean
-    and Mesoamerican gene pools indicating its early appearance. The other
-    haplotypes were gene pool-specific, including the v-lae pink-flowered
-    haplotypes in the Andean gene pool (McClean, Lee et al., 2022).
+  - Nine total P. vulgaris F3′5′H CDS haplotypes were discovered among the
+    screened genotypes. Eight recessive haplotypes of the V locus that control
+    pink or white flower color, defined by mutations of key functional domains
+    required for P450 activities, evolved independently in the two bean gene
+    pools from a common ancestral gene. The white v[Mex235] haplotype was
+    discovered in both Andean and Mesoamerican gene pools indicating its early
+    appearance. The other haplotypes were gene pool-specific, including the
+    v-lae pink-flowered haplotypes in the Andean gene pool (McClean, Lee et al.,
+    2022).
   - Evidence that V encodes F3′5′H was provided by the discovery of the v-lae
     [M0056] white-flowering haplotype. M0056 was produced by a natural
     intragenic recombination event between the v-lae [MDRK] (pink flower) and v
@@ -73,15 +75,19 @@ comments:
     Arabidopsis transformed with the wild-type allele remained unaffected (Liu,
     Yang et al., 2023).
   - Protein and domain modeling determined the V gene encodes the enzyme
-    Flavonoid 3′,5′-hydroxylase (F3′5′H) (McClean, Lee et al., 2022). This
-    member of the cytochrome P450 family is required for the expression of
-    dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
-    Specifically, F3’5’H converts the dihydroflavonols named dihydrokaempferol
-    (DHK) and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of
-    the blue-to-red pH-sensitive plant pigment delphinidin, its methylated
-    derivatives such as petunidin and malvidin, and its glycoside-containing
-    anthocyanin derivatives such as delphinidin 3-O-glucoside (Liu, Yang et al.,
-    2023).
+    Flavonoid 3′,5′-hydroxylase (F3′5′H), a member of the cytochrome P450 family
+    (McClean, Lee et al., 2022). Sequence analysis of Phvul.006G018800 protein
+    identified six conserved substrate recognition sites (SRS) and the four
+    functional motifs typical of Cytochrome P enzymes. Almost all these domain
+    sequences were nearly the same as the functional F3′5′H domains of other
+    legumes.
+  - F3'5'H is is required for the expression of dihydromyricetin-derived
+    flavonoids (McClean, Lee et al., 2022). Specifically, F3’5’H converts the
+    dihydroflavonols named dihydrokaempferol (DHK) and dihydroquercetin (DHQ) to
+    dihydromyricetin (DHM), a precursor of the blue-to-red pH-sensitive plant
+    pigment delphinidin, its methylated derivatives such as petunidin and
+    malvidin, and its glycoside-containing anthocyanin derivatives such as
+    delphinidin 3-O-glucoside (Liu, Yang et al., 2023).
 phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
   biosynthesis in common bean and results in purple coloration of many tissues.
 traits:

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -11,14 +11,15 @@ confidence: 5
 curators:
   - Scott Kalberer
 comments:
-  - The classical V (Violet, Purple) locus of Phaseolus vulgaris affects the colors of seed coats and flowers.
-    Plants with the dominant V allele are purple-flowered whereas homozygous
-    recessive plants exhibit white (v) or pink (v-lae) flowers. The dominant V
-    allele is associated with black-seeded beans, even as recessive v alleles produce seeds without
+  - The classical V (Violet, Purple) locus of Phaseolus vulgaris affects the
+    colors of seed coats and flowers. Plants with the dominant V allele are
+    purple-flowered whereas homozygous recessive plants exhibit white (v) or
+    pink (v-lae) flowers. The dominant V allele is associated with black-seeded
+    beans, even as recessive v alleles produce seeds without
     dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
-  - Solely genotypes carrying the dominant V allele produced the
-    anthocyanin named delphinidin 3-O-glucoside in seed coats. The colors of
-    these lines ranged from blue to black (Beninger and Hosfield, 2003).
+  - Solely genotypes carrying the dominant V allele produced the anthocyanin
+    named delphinidin 3-O-glucoside in seed coats. The colors of these lines
+    ranged from blue to black (Beninger and Hosfield, 2003).
   - Phytochemical analysis showed that dihydromyricetin-related compounds
     (e.g.,delphinidin 3-glucoside, myricetin 3-glucoside) were absent in flowers
     from introgression lines with recessive v alleles, greatly reduced in seed
@@ -26,15 +27,15 @@ comments:
     white-flowered v lines. The purple-flowered V dominant-allele lines had
     flowers and seeds containing these compounds (McClean, Lee et al., 2022).
   - McClean, Lee et al. (2022) physically mapped the V locus to a narrow
-    interval surrounding a Flavonoid 3′5’Hydroxylase (F3′5′H) candidate gene model (Phvul.006G018800) on
-    chromosome Pv06. This low recombination heterochromoatic region resisted
-    fine-mapping and the RAPD marker OD12-800 and 15 indels all co-segregated
-    with V. Knowing the V locus to be associated with F3′5′H, a search for gene
-    models including the F3′5′H KEGG identifier K13083 within the suspected Pv06
-    region of the reference genome G19833 revealed the gene model
-    Phvul.006G018800.
-  - Garcia-Fernandez, Campa et al. (2021) mapped a ‘TU’ × ‘Musica’
-    RIL population and showed that one of two genes responsible for a black seed
+    interval surrounding a Flavonoid 3′5’Hydroxylase (F3′5′H) candidate gene
+    model (Phvul.006G018800) on chromosome Pv06. This low recombination
+    heterochromoatic region resisted fine-mapping and the RAPD marker OD12-800
+    and 15 indels all co-segregated with V. Knowing the V locus to be associated
+    with F3′5′H, a search for gene models including the F3′5′H KEGG identifier
+    K13083 within the suspected Pv06 region of the reference genome G19833
+    revealed the gene model Phvul.006G018800.
+  - Garcia-Fernandez, Campa et al. (2021) mapped a ‘TU’ × ‘Musica’ RIL
+    population and showed that one of two genes responsible for a black seed
     coat phenotype was localized to a Pv06 region associated with locus V. They
     also proposed Phvul.006G018800 as the candidate V gene. Yet another study
     found Phvul.006G018800, the candidate gene for a Purple Mutation (PvPUR),
@@ -59,10 +60,10 @@ comments:
     activities, evolved independently in the two bean gene pools from a common
     ancestral haplotype V-[5-593]. Dominant V-[5-593] expression was connected
     to purple flowers in Mesoamerican and Andean gene pools. The white
-    v-[Mex235] haplotype was discovered in both gene
-    pools indicating its early emergence. Other haplotypes were gene
-    pool-specific, including the v-lae pink-flowered haplotypes in the Andean
-    gene pool (McClean, Lee et al., 2022).
+    v-[Mex235] haplotype was discovered in both gene pools indicating its early
+    emergence. Other haplotypes were gene pool-specific, including the v-lae
+    pink-flowered haplotypes in the Andean gene pool (McClean, Lee et al.,
+    2022).
   - Definitive evidence that V encodes F3′5′H was provided by discovery of the
     v-[M0056] white-flowering haplotype. This v-[M0056] was produced by a
     natural intragenic crossover event between the v-lae[MDRK] (pink flower) and

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -11,77 +11,40 @@ confidence: 5
 curators:
   - Scott Kalberer
 comments:
-  - The classical V (violet, purple) locus of Phaseolus vulgaris functions
-    alongside other genes to control colors of seed coats and flowers as well as
-    flavonoid content. Plants with the dominant V allele are purple-flowered
-    whereas homozygous recessive plants exhibit white (v) or pink (v-lae)
-    flowers. The dominant V allele is associated with black-seeded beans in the
-    presence of dominant B and G alleles, and recessive v alleles produce seeds
-    without dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
-  - Solely those genotypes carrying the dominant V allele were found to produce
-    the anthocyanin named delphinidin 3-O-glucoside in seed coats. The colors of
+  - The classical V (violet, purple) locus of Phaseolus vulgaris functions as
+    part of a genetic system that controls colors of seed coats and flowers.
+    Plants with the dominant V allele are purple-flowered whereas homozygous
+    recessive plants exhibit white (v) or pink (v-lae) flowers. The dominant V
+    allele is associated with black-seeded beans in the presence of dominant B
+    and G alleles, even as recessive v alleles produce seeds without
+    dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
+  - Solely genotypes carrying the dominant V allele were found to produce the
+    anthocyanin named delphinidin 3-O-glucoside in seed coats. The colors of
     these lines ranged from blue to black (Beninger and Hosfield, 2003).
   - Phytochemical analysis showed that dihydromyricetin-related compounds
-    (e.g.,delphinidin 3-glucoside and myricetin 3-glucoside) were absent in
-    flowers from introgression lines with recessive v alleles, greatly reduced
-    in seed coats of pink-flowered v-lae lines, and absent in the seed coats of
+    (e.g.,delphinidin 3-glucoside, myricetin 3-glucoside) were absent in flowers
+    from introgression lines with recessive v alleles, greatly reduced in seed
+    coats of pink-flowered v-lae lines, and absent in the seed coats of
     white-flowered v lines. The purple-flowered V dominant-allele lines had
-    flowers and seeds containing these compounds that were known to require the
-    active F3′5′H enzyme (McClean, Lee et al., 2022).
+    flowers and seeds containing these compounds known to require synthesis by
+    the active Flavonoid 3′5’Hydroxylase (F3′5′H) enzyme (McClean, Lee et al.,
+    2022).
   - McClean, Lee et al. (2022) physically mapped the V locus to a narrow
     interval surrounding a F3′5′H candidate gene model (Phvul.006G018800) on
-    chromosome Pv06. This low recombination heterochromoatic region of the
-    chromosome resisted fine-mapping and RAPD marker OD12-800 and 15 indels all
-    co-segregated with V. Knowing that the V locus was associated with the
-    F3′5′H enzyme, a search for gene models with the F3′5′H KEGG identifier
-    K13083 within the suspected Pv06 region of the reference Andean genome
-    G19833 revealed the gene model Phvul.006G018800.
-  - Additionally, Garcia-Fernandez, Campa et al. (2021) mapped
-    a ‘TU’ × ‘Musica’ recombinant-inbred line (RIL) population and showed that
-    one of two genes responsible for a black seed coat phenotype was localized
-    to a region of Pv06 associated with classical locus V. They also proposed
-    Phvul.006G018800, which encodes a flavonoid 3′5’hydroxylase, as the
-    candidate V gene. Yet another study found Phvul.006G018800, now the
-    candidate gene for Purple Mutation (PvPUR), was localized to the 243.9-kb
-    region of Pv06 (Liu, Yang et al., 2023).
-  - Nine total P. vulgaris F3′5′H CDS haplotypes were discovered among the
-    screened genotypes. Eight recessive haplotypes of the V locus that control
-    pink or white flower color, defined by mutations of key functional domains
-    required for P450 activities, evolved independently in the two bean gene
-    pools from a common ancestral dominant haplotype V-[5-593]. V-[5-593]
-    expression caused purple flowers in both Middle American and Andean gene
-    pools. The white v-[Mex235] haplotype was discovered in both Andean and
-    Mesoamerican gene pools indicating its early appearance. The other
-    haplotypes were gene pool-specific, including the v-lae pink-flowered
-    haplotypes in the Andean gene pool (McClean, Lee et al., 2022).
-  - Definitive evidence that V encodes F3′5′H was provided by the discovery of
-    the v-[M0056] white-flowering haplotype. This v-[M0056] was produced by a
-    natural intragenic crossover event between the v-lae[MDRK] (pink flower) and
-    v-[Mex235] (white flower) haplotypes. The 14-nt deletion within the
-    v-[Mex235] chromosome resulted in a frame-shift stop codon that eliminated
-    the heme-binding domain and SRS6 regions of F3'5'H. The v-[M0056]
-    recombinant haplotype contains the 5′-end of v-lae[MDRK] alongside the
-    3′-end of v-[Mex235] that removed F3'5'H functionality. Experimentally, if a
-    section of a candidate gene were to be deleted and a phenotypic change
-    observed, one would conclude that the candidate gene was validated. This
-    recombination event is a natural equivalent to gene editing in a species, P.
-    vulgaris, in which complementation technologies have yet to be developed
-    (McClean, Lee et al., 2022).
-  - Purple mutants of snap beans (Phaseolus vulgaris) exhibited purple
-    cotyledons, hypocotyls, stems, leaf veins, flower and pod tissues (Liu, Yang
-    et al., 2023). Levels of total anthocyanins, delphinidins, and malvidins in
-    purple-mutant pods were significantly higher than in wild-type plants (Liu,
-    Yang et al., 2023). Six single-base mutations within the coding region of
-    PvPUR altered the protein structure of F3’5’H resulting in the purple
-    phenotype (Liu, Yang et al., 2023).
-  - To validate the candidate gene's function, Arabidopsis thaliana were
-    transformed using wild-type and purple-mutant common bean alleles. Compared
-    with the wild-type Arabidopsis, the leaf bases and internodes of plants
-    receiving the purple-mutant allele were purple, whereas the phenotypes of
-    Arabidopsis transformed with the wild-type allele remained unaffected (Liu,
-    Yang et al., 2023).
+    chromosome Pv06. This low recombination heterochromoatic region resisted
+    fine-mapping and the RAPD marker OD12-800 and 15 indels all co-segregated
+    with V. Knowing the V locus to be associated with F3′5′H, a search for gene
+    models including the F3′5′H KEGG identifier K13083 within the suspected Pv06
+    region of the reference genome G19833 revealed the gene model
+    Phvul.006G018800.
+  - Additionally, Garcia-Fernandez, Campa et al. (2021) mapped a ‘TU’ × ‘Musica’
+    RIL population and showed that one of two genes responsible for a black seed
+    coat phenotype was localized to a Pv06 region associated with locus V. They
+    also proposed Phvul.006G018800 as the candidate V gene. Yet another study
+    found Phvul.006G018800, the candidate gene for a Purple Mutation (PvPUR),
+    was localized to the 243.9-kb region of Pv06 (Liu, Yang et al., 2023).
   - Protein and domain modeling determined the V gene encodes the enzyme
-    Flavonoid 3′,5′-hydroxylase (F3′5′H), a member of the cytochrome P450 family
+    Flavonoid 3′,5′-Hydroxylase (F3′5′H), a member of the cytochrome P450 family
     (McClean, Lee et al., 2022). Sequence analysis of Phvul.006G018800 protein
     identified six conserved substrate recognition sites (SRS) and the four
     functional motifs typical of Cytochrome P enzymes. Almost all these domain
@@ -94,8 +57,47 @@ comments:
     pigment delphinidin, its methylated derivatives such as petunidin and
     malvidin, and its glycoside-containing anthocyanin derivatives such as
     delphinidin 3-O-glucoside (Liu, Yang et al., 2023).
-phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
-  biosynthesis in common bean and results in purple coloration of many tissues.
+  - Nine total F3′5′H CDS haplotypes were discovered among the screened
+    genotypes. Eight recessive haplotypes that control pink or white flower
+    color, defined by mutations of functional domains required for P450
+    activities, evolved independently in the two bean gene pools from a common
+    ancestral dominant haplotype V-[5-593]. V-[5-593] expression was connected
+    to purple flowers in Middle American and Andean gene pools. The white
+    v-[Mex235] haplotype was discovered in both Andean and Mesoamerican gene
+    pools indicating its early emergence. The other haplotypes were gene
+    pool-specific, including the v-lae pink-flowered haplotypes in the Andean
+    gene pool (McClean, Lee et al., 2022).
+  - Definitive evidence that V encodes F3′5′H was provided by discovery of the
+    v-[M0056] white-flowering haplotype. This v-[M0056] was produced by a
+    natural intragenic crossover event between the v-lae[MDRK] (pink flower) and
+    v-[Mex235] (white flower) haplotypes. The 14-nt deletion within the
+    v-[Mex235] chromosome resulted in a frame-shift stop codon that eliminated
+    the heme-binding domain and SRS6 functional regions of F3'5'H. The v-[M0056]
+    recombinant haplotype contains the 5′-end of v-lae[MDRK] alongside the
+    3′-end of v-[Mex235]. Experimentally, if a section of a candidate gene were
+    to be deleted and a phenotypic change observed, one would conclude the
+    candidate gene was validated. This recombination event is a natural
+    equivalent to gene editing in a species, P. vulgaris, in which
+    complementation technologies have yet to be developed (McClean, Lee et al.,
+    2022).
+  - Purple mutants of P. vulgaris exhibited purple cotyledons, hypocotyls,
+    stems, leaf veins, flower and pod tissues (Liu, Yang et al., 2023). Levels
+    of total anthocyanins, delphinidins, and malvidins in purple-mutant pods
+    were significantly higher than in wild-type plants (Liu, Yang et al., 2023).
+    Six single-base mutations within the coding region of PvPUR altered the
+    protein structure of F3’5’H resulting in the purple phenotype (Liu, Yang et
+    al., 2023).
+  - To validate the candidate gene's function, Arabidopsis thaliana were
+    transformed using wild-type and purple-mutant common bean alleles. Compared
+    with the wild-type Arabidopsis, the leaf bases and internodes of plants
+    receiving the purple-mutant allele were purple, whereas the phenotypes of
+    Arabidopsis transformed with the wild-type allele remained unaffected (Liu,
+    Yang et al., 2023).
+phenotype_synopsis: The Violet (V) gene in Phaseolus vulgaris encodes the
+  cytochrome P450 enzyme Flavonoid 3′,5′-Hydroxylase (F3′5′H). Functional V
+  expression is needed for the biosynthesis of dihydromyricetin-derived
+  flavonoids and affects the coloration of flowers, seed coats, and many other
+  tissues.
 traits:
   - entity_name: flavonoid content
     entity: TO:0000290

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -1,0 +1,45 @@
+---
+scientific_name: Phaseolus vulgaris
+classical_locus: V
+gene_symbols:
+  - PvPUR
+gene_symbol_long: Purple Mutation
+gene_model_pub_name: Phvul.006G018800
+gene_model_full_id: phavu.G19833.gnm2.ann1.Phvul.006G018800
+confidence: 5
+curators:
+  - Scott Kalberer
+comments:
+  - Purple mutants of snap beans (the common bean Phaseolus vulgaris) exhibit
+    purple cotyledons, hypocotyls, stems, leaf veins, flower and pod tissues.
+  - Levels of total anthocyanins, delphinidins, and malvidins in purple-mutant
+    pods were significantly higher than in wild-type plants.
+  - Phvul.006G018800, the candidate gene for Purple Mutation (PvPUR), is
+    localized to the 243.9-kb region of chromosome Pv06. The gene encodes the
+    enzyme Flavonoid 3',5'-hydroxylase (F3’5’H), a member of the cytochrome P450
+    family. F3’5’H converts the dihydroflavonols named dihydrokaempferol (DHK)
+    and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of the
+    blue-to-red pH-sensitive plant pigment delphinidin and its anthocyanin
+    derivatives.
+  - Six single-base mutations within the coding region of PvPUR altered the
+    protein structure of F3’5’H resulting in the purple phenotype.
+  - To validate the candidate gene's function, Arabidopsis thaliana were
+    transformed using wild-type and purple-mutant common bean alleles. Compared
+    with the wild-type Arabidopsis, the leaf bases and internodes of plants
+    receiving the purple-mutant allele were purple, whereas the phenotypes of
+    Arabidopsis transformed with the wild-type allele remained unaffected.
+phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
+  biosynthesis in common bean and results in purple coloration of many tissues.
+traits:
+  - entity_name: anthocyanin content
+    entity: TO:0000071
+references:
+  - citation: McClean, Lee et al., 2022
+    doi: 10.3389/fpls.2022.869582
+    pmid: 35432409
+  - citation: Liu, Yang et al., 2023
+    doi: 10.1007/s11032-023-01362-8
+    pmid: 37313298
+  - citation: Liu, Yang et al., 2022
+    doi: 10.3390/ijms23031265
+    pmid: 35163188

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -10,32 +10,17 @@ confidence: 5
 curators:
   - Scott Kalberer
 comments:
-  - Purple mutants of snap beans (the common bean Phaseolus vulgaris) exhibit
-    purple cotyledons, hypocotyls, stems, leaf veins, flower and pod tissues
-    (Liu, Yang et al., 2023).
-  - Levels of total anthocyanins, delphinidins, and malvidins in purple-mutant
-    pods were significantly higher than in wild-type plants (Liu, Yang et al.,
-    2023).
-  - The classical V (violet, purple) gene of Phaseolus vulgaris functions within
-    a genetic network that controls seed coat and flower color and flavonoid
-    content (McClean, Lee et al., 2022).
-  - Solely genotypes carrying the dominant V allele were found to produce the
-    anthocyanin named delphinidin 3-O-glucoside in seed coats. These color of
-    these lines were blue to black in color (Beninger and Hosfield, 2003).
-  - The V locus was mapped to a narrow interval on chromosome Pv06. A candidate
-    gene was selected based on flavonoid analysis and confirmed by
-    recombinational mapping. Protein and domain modeling determined that V
-    encodes the enzyme flavonoid 3′5′ hydroxylase (F3′5′H), a P450 enzyme
-    required for the expression of dihydromyricetin-derived flavonoids in the
-    flavonoid pathway. F3′5′H evolved as a major target gene for the evolution
-    of flower and seed coat color in plants (McClean, Lee et al., 2022).
-  - Phvul.006G018800, the candidate gene for Purple Mutation (PvPUR), is
-    localized to the 243.9-kb region of chromosome Pv06. The gene encodes the
-    enzyme Flavonoid 3',5'-hydroxylase (F3’5’H), a member of the cytochrome P450
-    family. F3’5’H converts the dihydroflavonols named dihydrokaempferol (DHK)
-    and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of the
-    blue-to-red pH-sensitive plant pigment delphinidin and its anthocyanin
-    derivatives (Liu, Yang et al., 2023).
+  - The classical V (violet, purple) locus of Phaseolus vulgaris functions
+    alongside other genes to control colors of seed coats and flowers as well as
+    flavonoid content (McClean, Lee et al., 2022).
+  - Solely those genotypes carrying the dominant V allele were found to produce
+    the anthocyanin named delphinidin 3-O-glucoside in seed coats. The colors of
+    these lines ranged from blue to black (Beninger and Hosfield, 2003).
+  - A candidate gene for the V locus, suggested by flavonoid analysis and
+    recombinational mapping, was found in a narrow interval on chromosome Pv06
+    (McClean, Lee et al., 2022). Another study found Phvul.006G018800, the
+    candidate gene for Purple Mutation (PvPUR), was localized to the 243.9-kb
+    region of chromosome Pv06 (Liu, Yang et al., 2023).
   - Eight recessive haplotypes of the V locus, defined by mutations of key
     functional domains required for P450 activities, evolved independently in
     the two bean gene pools from a common ancestral gene (McClean, Lee et al.,
@@ -43,23 +28,33 @@ comments:
   - Evidence that V encodes F3′5′H was provided by the discovery of the vlae
     [M0056] white-flowering haplotype. M0056 was produced by a natural
     intragenic recombination event between the vlae [MDRK] (pink flower) and v
-    [Mex235] (white flower) haplotypes. A deletion was introduced to the vlae
-    [MDRK] haplotype, resulting in a frame-shift stop codon that eliminated the
-    essential heme-binding and SRS6 regions. This recombination event is a
-    natural equivalent to gene editing in a species, P. vulgaris, in which such
-    complementation technologies have yet to be developed. When a section of the
-    candidate gene is deleted, and the resultant progeny shows a phenotypic
-    change, the candidate gene is revealed as the causative gene for the
-    phenotype (McClean, Lee et al., 2022).
-  - Six single-base mutations within the coding region of PvPUR altered the
-    protein structure of F3’5’H resulting in the purple phenotype (Liu, Yang et
-    al., 2023).
+    [Mex235] (white flower) haplotypes. A deletion introduced to the vlae [MDRK]
+    haplotype resulted in a frame-shift stop codon that eliminated the essential
+    heme-binding and SRS6 regions. This recombination event is a natural
+    equivalent to gene editing in a species, P. vulgaris, in which such
+    complementation technologies have yet to be developed (McClean, Lee et al.,
+    2022).
+  - Purple mutants of snap beans (Phaseolus vulgaris) exhibited purple
+    cotyledons, hypocotyls, stems, leaf veins, flower and pod tissues (Liu, Yang
+    et al., 2023). Levels of total anthocyanins, delphinidins, and malvidins in
+    purple-mutant pods were significantly higher than in wild-type plants (Liu,
+    Yang et al., 2023). Six single-base mutations within the coding region of
+    PvPUR altered the protein structure of F3’5’H resulting in the purple
+    phenotype (Liu, Yang et al., 2023).
   - To validate the candidate gene's function, Arabidopsis thaliana were
     transformed using wild-type and purple-mutant common bean alleles. Compared
     with the wild-type Arabidopsis, the leaf bases and internodes of plants
     receiving the purple-mutant allele were purple, whereas the phenotypes of
     Arabidopsis transformed with the wild-type allele remained unaffected (Liu,
     Yang et al., 2023).
+  - Protein and domain modeling determined the V gene encodes the enzyme
+    Flavonoid 3′,5′-hydroxylase (F3′5′H) (McClean, Lee et al., 2022). This
+    member of the cytochrome P450 family is required for the expression of
+    dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
+    Specifically, F3’5’H converts the dihydroflavonols named dihydrokaempferol
+    (DHK) and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of
+    the blue-to-red pH-sensitive plant pigment delphinidin and its anthocyanin
+    derivatives (Liu, Yang et al., 2023).
 phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
   biosynthesis in common bean and results in purple coloration of many tissues.
 traits:

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -37,6 +37,17 @@ comments:
     functional domains required for P450 activities, evolved independently in
     the two bean gene pools from a common ancestral gene (McClean, Lee et al.,
     2022).
+  - Evidence that V encodes F3′5′H was provided by the discovery of the vlae
+  [M0056] white-flowering haplotype. M0056 was produced by a natural intragenic
+  recombination event between the vlae [MDRK] (pink flower) and v [Mex235]
+  (white flower) haplotypes. A deletion was introduced to the vlae [MDRK]
+  haplotype, resulting in a frame-shift stop codon that eliminated the essential
+  heme-binding and SRS6 regions. This recombination event is a natural
+  equivalent to gene editing in a species, P. vulgaris, in which such
+  complementation technologies have yet to be developed. When a section of the
+  candidate gene is deleted, and the resultant progeny shows a phenotypic
+  change, the candidate gene is revealed as the causative gene for the phenotype
+  (McClean, Lee et al., 2022).
   - Six single-base mutations within the coding region of PvPUR altered the
     protein structure of F3’5’H resulting in the purple phenotype (Liu, Yang et
     al., 2023).

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -62,7 +62,7 @@ comments:
     dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
     Specifically, F3’5’H converts the dihydroflavonols named dihydrokaempferol
     (DHK) and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of
-    the blue-to-red pH-sensitive plant pigment delphinidin and its anthocyanin
+    the blue-to-red pH-sensitive plant pigment delphinidin, its methylated derivatives such as petunidin and malvidin, and its glycoside-containing anthocyanin
     derivatives such as delphinidin 3-O-glucoside (Liu, Yang et al., 2023).
 phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
   biosynthesis in common bean and results in purple coloration of many tissues.

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -16,11 +16,20 @@ comments:
   - Solely those genotypes carrying the dominant V allele were found to produce
     the anthocyanin named delphinidin 3-O-glucoside in seed coats. The colors of
     these lines ranged from blue to black (Beninger and Hosfield, 2003).
-  - A candidate gene for the V locus, suggested by flavonoid analysis and
-    recombinational mapping, was found in a narrow interval on chromosome Pv06
-    (McClean, Lee et al., 2022). Another study found Phvul.006G018800, the
+  - Biochemical analysis of introgression lines, which shared a genetic
+    background but incorporated different recessive v alleles, showed that
+    dihydromyricetin-related compounds (e.g.,delphinidin) were greatly reduced
+    in seeds and flowers with recessive v alleles (McClean, Lee et al., 2022).
+  - McClean, Lee et al. (2022) physically mapped the V locus to a narrow
+    interval surrounding a F3′5′H candidate gene model (Phvul.006G018800) on
+    chromosome Pv06. Additionally, Garcia-Fernandez, Campa et al. (2021) mapped
+    a ‘TU’ × ‘Musica’ recombinant-inbred line (RIL) population and showed that
+    one of two genes responsible for a black seed coat phenotype was localized
+    to a region of Pv06 associated with classical locus V. They also proposed
+    Phvul.006G018800, which encodes a flavonoid 3′5’hydroxylase, as the
+    candidate V gene. Yet another study found Phvul.006G018800, now the
     candidate gene for Purple Mutation (PvPUR), was localized to the 243.9-kb
-    region of chromosome Pv06 (Liu, Yang et al., 2023).
+    region of Pv06 (Liu, Yang et al., 2023).
   - Eight recessive haplotypes of the V locus, defined by mutations of key
     functional domains required for P450 activities, evolved independently in
     the two bean gene pools from a common ancestral gene (McClean, Lee et al.,

--- a/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
+++ b/Phaseolus/vulgaris/studies/phavu.McClean_Lee_2022.yml
@@ -12,17 +12,30 @@ curators:
 comments:
   - The classical V (violet, purple) locus of Phaseolus vulgaris functions
     alongside other genes to control colors of seed coats and flowers as well as
-    flavonoid content (McClean, Lee et al., 2022).
+    flavonoid content. Plants with the dominant V allele are purple-flowered
+    whereas homozygous recessive plants exhibit white (v) or pink (v-lae)
+    flowers. The dominant V allele is associated with black-seeded beans in the
+    presence of dominant B and G alleles, and recessive v alleles produce seeds
+    without dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
   - Solely those genotypes carrying the dominant V allele were found to produce
     the anthocyanin named delphinidin 3-O-glucoside in seed coats. The colors of
     these lines ranged from blue to black (Beninger and Hosfield, 2003).
-  - Biochemical analysis of introgression lines, which shared a genetic
-    background but incorporated different recessive v alleles, showed that
-    dihydromyricetin-related compounds (e.g.,delphinidin) were greatly reduced
-    in seeds and flowers with recessive v alleles (McClean, Lee et al., 2022).
+  - Phytochemical analysis showed that dihydromyricetin-related compounds
+    (e.g.,delphinidin 3-glucoside and myricetin 3-glucoside) were absent in
+    flowers from introgression lines with recessive v alleles, greatly reduced
+    in seed coats of pink-flowered v-lae lines, and absent in the seed coats of
+    white-flowered v lines. The purple-flowered V dominant-allele lines had
+    flowers and seeds containing these compounds that were known to require the
+    active F3′5′H enzyme (McClean, Lee et al., 2022).
   - McClean, Lee et al. (2022) physically mapped the V locus to a narrow
     interval surrounding a F3′5′H candidate gene model (Phvul.006G018800) on
-    chromosome Pv06. Additionally, Garcia-Fernandez, Campa et al. (2021) mapped
+    chromosome Pv06. This low recombination heterochromoatic region of the
+    chromosome resisted fine-mapping and RAPD marker OD12-800 and 15 indels all
+    co-segregated with V. Knowing that the V locus was associated with the
+    F3′5′H enzyme, a search for gene models with the F3′5′H KEGG identifier
+    K13083 within the suspected Pv06 region of the reference Andean genome
+    G19833 revealed the gene model Phvul.006G018800.
+  - Additionally, Garcia-Fernandez, Campa et al. (2021) mapped
     a ‘TU’ × ‘Musica’ recombinant-inbred line (RIL) population and showed that
     one of two genes responsible for a black seed coat phenotype was localized
     to a region of Pv06 associated with classical locus V. They also proposed
@@ -30,14 +43,17 @@ comments:
     candidate V gene. Yet another study found Phvul.006G018800, now the
     candidate gene for Purple Mutation (PvPUR), was localized to the 243.9-kb
     region of Pv06 (Liu, Yang et al., 2023).
-  - Eight recessive haplotypes of the V locus, defined by mutations of key
-    functional domains required for P450 activities, evolved independently in
-    the two bean gene pools from a common ancestral gene (McClean, Lee et al.,
-    2022).
-  - Evidence that V encodes F3′5′H was provided by the discovery of the vlae
+  - Eight recessive haplotypes of the V locus that control pink or white flower
+    color, defined by mutations of key functional domains required for P450
+    activities, evolved independently in the two bean gene pools from a common
+    ancestral gene. The white v[Mex235] haplotype was discovered in both Andean
+    and Mesoamerican gene pools indicating its early appearance. The other
+    haplotypes were gene pool-specific, including the v-lae pink-flowered
+    haplotypes in the Andean gene pool (McClean, Lee et al., 2022).
+  - Evidence that V encodes F3′5′H was provided by the discovery of the v-lae
     [M0056] white-flowering haplotype. M0056 was produced by a natural
-    intragenic recombination event between the vlae [MDRK] (pink flower) and v
-    [Mex235] (white flower) haplotypes. A deletion introduced to the vlae [MDRK]
+    intragenic recombination event between the v-lae [MDRK] (pink flower) and v
+    [Mex235] (white flower) haplotypes. A deletion introduced to the v-lae [MDRK]
     haplotype resulted in a frame-shift stop codon that eliminated the essential
     heme-binding and SRS6 regions. This recombination event is a natural
     equivalent to gene editing in a species, P. vulgaris, in which such
@@ -62,8 +78,10 @@ comments:
     dihydromyricetin-derived flavonoids (McClean, Lee et al., 2022).
     Specifically, F3’5’H converts the dihydroflavonols named dihydrokaempferol
     (DHK) and dihydroquercetin (DHQ) to dihydromyricetin (DHM), a precursor of
-    the blue-to-red pH-sensitive plant pigment delphinidin, its methylated derivatives such as petunidin and malvidin, and its glycoside-containing anthocyanin
-    derivatives such as delphinidin 3-O-glucoside (Liu, Yang et al., 2023).
+    the blue-to-red pH-sensitive plant pigment delphinidin, its methylated
+    derivatives such as petunidin and malvidin, and its glycoside-containing
+    anthocyanin derivatives such as delphinidin 3-O-glucoside (Liu, Yang et al.,
+    2023).
 phenotype_synopsis: The gene Purple Mutation (PvPUR) impacts anthocyanin
   biosynthesis in common bean and results in purple coloration of many tissues.
 traits:


### PR DESCRIPTION
I have finished production of the Common Bean gene function file named phavu.McClean_Lee_2022.yml that assesses the Violet (Purple) locus that affects flower and seed coat color phenotypes. I would like these modifications reviewed, and if the product is adequate, for the branch phavu.McClean_Lee_2022 to be merged into the main branch.