### PR TITLE
Create  medtr.Seabra_Vieria_2010.yml

### DIFF
--- a/Medicago/truncatula/studies/medtr.Seabra_Vieria_2010.yml
+++ b/Medicago/truncatula/studies/medtr.Seabra_Vieria_2010.yml
@@ -1,0 +1,50 @@
+---
+scientific_name: Medicago truncatula
+gene_symbols:
+  - MtGS2b
+gene_symbol_long: PLASTID GLUTAMINE SYNTHETASE b
+gene_model_pub_name: Medtr2g021242
+gene_model_full_id: medtr.A17_HM341.gnm4.ann2.Medtr2g021242
+confidence: 4
+curators:
+  - Raegan Nelson
+comments:
+  - MtGS2b transcripts were detected exculsivly in developing seeds and seed pods
+  - MtGS2a has a high degree of homology with MtGS2b
+  - MtGS2b plays a role in seed metabloism
+  - The stronger and specific expression of MtGS2b during seed filling suggests that the enzyme plays a role in seed specific role related to reserve accumulation
+phenotype_synopsis: MtGS2b plays a role in seed metabloism and seed storage
+traits:
+  - entity_name: seed maturation
+    entity: TO:0002661
+  - entity_name: glutamine catabolic process
+    entity: GO:0006543
+references:
+  - citation: Seabra, Vieria et al., 2010
+    doi: 10.1186/1471-2229-10-183
+    pmid: 20723225
+---
+scientific_name: Medicago truncatula
+gene_symbols:
+  - MtGS2a
+gene_symbol_long: PLASTID GLUTAMINE SYNTHETASE a
+gene_model_pub_name: Medtr2g021255
+gene_model_full_id: medtr.A17_HM341.gnm4.ann2.Medtr2g021255
+confidence: 5
+curators:
+  - Raegan Nelson
+comments:
+  - MtGS2a transcripts were detected in almost all organs of the plant, being generally more highly expressed in leaves, stems and cotyledon
+  - MtGS2a transcripts remain constant from 3-14 DAP but are absent at 20 DAP
+  - MtGS2a has a high degree of homology with MtGS2b
+  - MtGSba plays a role in seed metabloism
+phenotype_synopsis: MtGSa plays a role in seed metabloism
+traits:
+  - entity_name: seed maturation
+    entity: TO:0002661
+  - entity_name: glutamine catabolic process
+    entity: GO:0006543
+references:
+  - citation: Seabra, Vieria et al., 2010
+    doi: 10.1186/1471-2229-10-183
+    pmid: 20723225


### PR DESCRIPTION
Only issue was the public gene ID. The excel sheet that I find these papers on lists MtGS2b as 
Medtr2g021242 and MtGS2a as Medtr2g021255. The paper lists MtGS2b as Medtr2g026360 and MtGS2a as Medtr2g026390. 

When looking up the paper pub IDs on legume base, I could only find MtGS2a. The paper also listed an accession number AY225150 which was for MtGS2a. There was an accession number for MtGS2b, (AC202342) but that looks to be a segment of the Medicago genome and not specifically the MtGS2b gene. When tracing back AY225150 I found that it lined up with Medtr2g021255 which is what the excel sheet listed. 