### PR TITLE
Validator2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,10 +3,15 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu
 RUN apt-get update && apt-get install -y \
     vim \
     curl \
+    nodejs \
+    npm \
     && rm -rf /var/lib/apt/lists/*
 
 # Install mikefarah/yq (Go version)
 RUN curl -sSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
+
+# Install ajv-cli globally for validator scripts
+RUN npm install -g ajv-cli
 
 RUN echo 'set compatible' > /home/vscode/.vimrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,26 @@
 {
-	"name": "Gene Function Registry",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
-	"features": {
-		"ghcr.io/devcontainers/features/git:1": {}
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"redhat.vscode-yaml",
-				"esbenp.prettier-vscode",
-				"ms-python.python"
-			]
-		}
-	},
-	"forwardPorts": [],
-	"remoteUser": "vscode"
+    "name": "Gene Function Registry",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "lts",
+            "nodeGypDependencies": true,
+            "globalModules": "ajv-cli"
+        }
+    },
+    "postCreateCommand": "sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "redhat.vscode-yaml",
+                "esbenp.prettier-vscode",
+                "ms-python.python"
+            ]
+        }
+    },
+    "forwardPorts": [],
+    "remoteUser": "vscode"
 }

--- a/Medicago/truncatula/studies/medtr.Jun_Liu_2015.yml
+++ b/Medicago/truncatula/studies/medtr.Jun_Liu_2015.yml
@@ -8,7 +8,7 @@ gene_model_full_id: medtr.A17_HM341.gnm4.ann2.Medtr5g011250
 confidence: 5
 curators:
   - Steven Cannon
-phenotype_synopsis: MtANS (anthocyanidin synthase) gene expression was down-regulated in M. truncatula genotype R108 using an antisense construct.  Anthocyanin levels were strongly reduced in leaf tissues of antisense lines.  The presence of a red anthocyanin-rich circle at the base of the axial side of the leaflet and small red dots on the adaxial side results from anthocyanin deposition.  Six independent transgenic antisense MtANS lines lacked the red circle and spots and another 10 such lines had reduced levels of pigmentation.  There was a strong reduction in the levels of both soluble and insoluble PAs (Oligomeric proanthocyanidins) in seeds, consistent with involvement of ANS in PA biosynthesis.
+phenotype_synopsis: In a M. truncatula genotype with an antisense construct for MtANS, anthocyanin levels were strongly reduced in leaf tissues, and here was a strong reduction in the levels of both soluble and insoluble PAs (Oligomeric proanthocyanidins) in seeds, consistent with involvement of ANS in PA biosynthesis.
 traits:
   - entity_name: anthocyanin content
     entity: TO:0000071

--- a/Medicago/truncatula/studies/medtr.Valdés-López_Jayaraman_2019.yml
+++ b/Medicago/truncatula/studies/medtr.Valdés-López_Jayaraman_2019.yml
@@ -24,6 +24,6 @@ traits:
   - entity_name: root hair
     entity: GO:0035618
 references:
-  - citation: Valdés-López, Jayaraman et al.,, 2019
+  - citation: Valdés-López, Jayaraman et al., 2019
     doi: 10.1093/pcp/pcy228
     pmid: 30476329

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ The traits.yml file contains one or more yaml "documents", indicated by three le
 ## Curation and review process
 Because the curation process for this type of data involves close reading and review of scientific literature, and because several curators will be doing this work, we will prepare the files away from the main Data Store. The workspace for drafting and reviewing the records is at the <a href="https://github.com/legumeinfo/gene-function-registry" target="_blank">gene-function-registry</a> with the yaml documents going into the respective Genus/species/studies directories. In general, a yaml document is associated with a publication (aka "study"), and is named in the `Author_Author_YEAR.yml` pattern. A manuscript may describe one or several genes. Each gene "record" should have its own "document" within the yaml file, where a "document" is signified by a line with three dashes at the top of the document.
 
-<strong>Note: After generating a new yaml file, check whether it is compliant yaml format with a format-checker such as <a href="https://www.yamllint.com" target="_blank">www.yamllint.com</a>.</strong>
+<strong>Note: After generating a new yaml file, validate it using the validate_gfr.sh script:</strong>
+```
+ Usage: ./scripts/validate_gfr.sh <path_to_yaml_file>
+ Example: ./scripts/validate_gfr.sh Pisum/sativum/studies/pissa.Feng_Chen_2024.yml
+```
 
 After review and revision if needed, new gene records (as yaml documents) will be added to the appropriate gensp.traits.yml file in the Data Store. Draft curation work will go into the <a href="https://github.com/legumeinfo/gene-function-registry" target="_blank">gene-function-registry</a> repository, and then go into the Data Store file system -- and from there, into the <a href="https://github.com/legumeinfo/datastore-metadata" target="_blank">datastore-metadata</a> repository.
 

--- a/schema.json
+++ b/schema.json
@@ -1,52 +1,95 @@
 {
-    "type": "object",
-    "properties": {
+  "type": "object",
+  "properties": {
+      "scientific_name": {
+          "description": "Genus species",
+          "type": "string",
+          "pattern": "^[A-Z][a-z]+ [a-z]+$"
+      },
       "classical_locus": {
-        "description": "Name of locus if available from classical genetic studies",
-        "type": "string"
+          "description": "Short string signifying genetic locus",
+          "type": "string",
+          "pattern": "^(?!none).*$"
       },
       "gene_symbols": {
-        "description": "List of gene symbols if available from literature",
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
+          "description": "List of gene symbols, in a yaml array",
+          "type": "array",
+          "items": {
+              "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
       },
       "gene_symbol_long": {
-        "description": "Descriptive name of gene symbol if available",
-        "type": "string"
+          "description": "Name of primary/first gene symbol",
+          "type": "string",
+          "pattern": "^(?!none).*$"
       },
       "gene_model_pub_name": {
-        "description": "Gene name from publication",
-        "type": "string"
+          "description": "Gene identifier used in the publication",
+          "type": "string"
       },
       "gene_model_full_id": {
-        "description": "Gene name in Data Store, with full prefix",
-        "type": "string"
+          "description": "Gene model name from LIS datastore, with prefix; form gensp.Strain.gnm#.ann#.geneID",
+          "type": "string",
+          "pattern": "^[^.\\s]+\\.[^.\\s]+\\.[^.\\s]+(\\.[^.\\s]+)*$"
       },
       "confidence": {
-        "description": "Confidence of association",
-        "minimum": 1,
-        "maximum": 5,
-        "type": "integer"
+          "description": "Integer between 1 and 5, with 5 indicating rigorous validation; 1 and 2 low confidence, and avoided",
+          "type": ["integer"],
+          "minimum": 3,
+          "maximum": 5
       },
       "curators": {
-        "description": "Name of curators who worked on this",
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
+          "description": "Name(s) of one or more curators, in a yaml array",
+          "type": "array",
+          "items": {
+              "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
       },
       "comments": {
-        "description": "Free text comments",
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
+          "description": "Comments explaining key aspects of the biology or curation, in a yaml array",
+          "type": "array",
+          "items": {
+              "type": "string"
+          }
       },
       "phenotype_synopsis": {
-        "description": "Brief free-text phenotype description, e.g. \"Seed raffinose concentration\" or \"photoperiod insensitivity to short day conditions\"",
-        "type": "string"
+          "description": "Short description of the phenotypic effect of the gene (mutant or over expression)", 
+          "type": "string",
+          "maxLength": 500,
+          "pattern": "^(?!none).*$"
+      },
+      "references": {
+        "description": "Array of citations with sub-array of doi and pmid",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+                      "citation": {
+                        "description": "String with format 'Author, Author et al., YEAR', 'Author, Author, YEAR', or 'Author, YEAR'",
+                        "type": "string",
+                        "pattern": "(^\\S+, \\S+ et al\\., \\d{4}$)|(^\\S+, \\S+, \\d{4}$)|(^\\S+, \\d{4}$)"
+                      },
+                      "doi": {
+                        "description": "DOI pointing to the dataset; NOTE this is NOT a URI!",
+                        "type": "string",
+                        "pattern": "10\\.\\d{4,9}.+"
+                      },
+                      "pmid": {
+                        "description": "PMID",
+                        "type": ["integer"],
+                        "maximum": 99999999
+                      }
+                    },
+            "required": ["citation"],
+              "anyOf": [
+                { "required": ["doi"] },
+                { "required": ["pmid"] }
+              ]
+        }
       },
       "traits": {
         "description": "List of traits associated with this gene",
@@ -54,64 +97,31 @@
         "items": {
           "type": "object",
           "properties": {
-            "entity_name": {
-              "description": "Short descriptive name of the ontology accession",
-              "type": "string"
+            "entity_name": { 
+              "description": "Human-readable name of ontology term, e.g., 'defense response to nematode'",
+              "type": "string",
+              "pattern": "^(?!none).*$"
             },
-            "entity": {
-              "description": "Ontology accession for the trait",
-              "type": "string"
+            "entity": { 
+              "description": "Ontology accession with format 'NS:###', where NS is the namespace, e.g. TO or GO",
+              "type": "string",
+              "pattern": "^[A-Za-z]+\\d*:\\d{7}$"
             },
-            "quality_name": {
-              "description": "Short descriptive name for accession quality term",
-              "type": "string"
+            "relation_name": { 
+              "description": "Human-readable name of ontology term, e.g., 'defense response to nematode'",
+              "type": "string",
+              "pattern": "^(?!none).*$"
             },
-            "quality": {
-              "description": "Ontology accession for the quality term",
-              "type": "string"
-            },
-            "relation_name": {
-              "description": "Short descriptive name for accession relation term",
-              "type": "string"
-            },
-            "relation": {
-              "description": "Ontology accession for the relation term",
-              "type": "string"
+            "relation": { 
+              "description": "Ontology accession with format 'RO:###', where RO is the relation ontology",
+              "type": "string",
+              "pattern": "^(RO|PATO):\\d{7}$"
             }
           }
         }
-      },
-      "references": {
-        "description": "List of references for this association",
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "citation": {
-              "description": "Citation in the format \"LastName, LastName et al., YEAR\"",
-              "type": "string"
-            },
-            "doi": {
-              "description": "DOI for the publication",
-              "type": "string"
-            },
-            "pmid": {
-              "description": "PubMed ID for the publication",
-              "minimum": 1,
-              "type": "integer"
-            }
-          }
-        }
-      } 
-    },
-    "additionalProperties": false,
-    "required": [
-      "confidence",
-      "gene_model_full_id",
-      "gene_model_pub_name",
-      "phenotype_synopsis",
-      "references",
-      "traits"
-    ]
+      }
+  },
+  "required": [ "scientific_name", "gene_symbols", "gene_model_pub_name", "gene_model_full_id", 
+                "confidence", "phenotype_synopsis", "traits", "references" ],
+  "additionalProperties": false
 }
-

--- a/scripts/validate_gfr.sh
+++ b/scripts/validate_gfr.sh
@@ -66,8 +66,10 @@ for (( i=0; i<NUM_DOCS; i++ )); do
     
     echo "  - Validating document $CURRENT_DOC_INDEX (0-indexed: $i)..."
     
-    # Create a temporary file for the current YAML document
-    TEMP_DOC_FILE=$(mktemp --suffix=".yml")
+    # Create a temporary file for the current YAML document. This works on both MacOS and Linux
+    export TMPDIR="${TMPDIR:-/tmp}"
+    TEMP_DOC_FILE=$(mktemp -p "$TMPDIR")
+    TEMP_DOC_FILE="${TEMP_DOC_FILE}.yml"
     
     # Extract the specific YAML document using yq and save it to the temporary file
     # 'select(document_index == $i)' extracts the document at index i (0-based)

--- a/scripts/validate_gfr.sh
+++ b/scripts/validate_gfr.sh
@@ -103,8 +103,10 @@ echo "Total documents failed:     $TOTAL_DOCUMENTS_FAILED"
 
 if [ "$FILE_HAS_ERRORS" = true ]; then
     echo "Overall Validation: FAILED (Some documents contain errors)."
+    echo ""
     exit 1
 else
     echo "Overall Validation: PASSED (All documents are valid)."
+    echo ""
     exit 0
 fi

--- a/scripts/validate_gfr.sh
+++ b/scripts/validate_gfr.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Define the path to the JSON schema, relative to this script's location.
+# Assuming schema.json is in the repository root.
+SCHEMA="$(dirname "$(realpath "$0")")/../schema.json"
+
+# --- Dependency Checks ---
+# Check if ajv-cli is installed
+if ! command -v ajv &> /dev/null; then
+    echo "Error: 'ajv' command not found."
+    echo "Please install ajv-cli globally: npm install -g ajv-cli"
+    exit 1
+fi
+
+# Check if yq (Mike Farrah's Go version 3+) is installed
+if ! command -v yq &> /dev/null || ! yq --version 2>&1 | grep -q 'version v[3-9]\.'; then
+    echo "Error: 'yq' (Mike Farrah's Go version 3+) command not found or is an incompatible version."
+    echo "Please install it from https://github.com/mikefarah/yq#install"
+    echo "Example: wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq && chmod +x /usr/local/bin/yq"
+    exit 1
+fi
+# --- End Dependency Checks ---
+
+# Check if a YAML file was provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <path_to_yaml_file>"
+    echo "Example: $0 Pisum/sativum/studies/pissa.Feng_Chen_2024.yml"
+    exit 1
+fi
+
+YML_FILE="$1"
+
+# Check if the provided file exists
+if [ ! -f "$YML_FILE" ]; then
+    echo "Error: YAML file not found: $YML_FILE"
+    exit 1
+fi
+
+TOTAL_DOCUMENTS_VALIDATED=0
+TOTAL_DOCUMENTS_FAILED=0
+FILE_HAS_ERRORS=false
+
+echo "--- Starting Multi-Document YAML Validation ---"
+echo "File:   $YML_FILE"
+echo "Schema: $SCHEMA"
+echo "-----------------------------------------------"
+
+# --- CORRECTED: Get the number of documents in the YAML file ---
+# We use 'eval-all . | ""' to process each document and output an empty string,
+# then 'wc -l' to count the lines, which corresponds to the number of documents.
+NUM_DOCS=$(yq eval-all '. | ""' "$YML_FILE" 2>/dev/null | wc -l)
+if [ $? -ne 0 ]; then
+    echo "Error: Could not determine number of documents in $YML_FILE using yq. Please check file format."
+    exit 1
+fi
+
+if [ "$NUM_DOCS" -eq 0 ]; then
+    echo "Warning: No YAML documents found in $YML_FILE. Nothing to validate."
+    exit 0
+fi
+
+# Loop through each document by index
+for (( i=0; i<NUM_DOCS; i++ )); do
+    CURRENT_DOC_INDEX=$((i + 1))
+    TOTAL_DOCUMENTS_VALIDATED=$((TOTAL_DOCUMENTS_VALIDATED + 1))
+    
+    echo "  - Validating document $CURRENT_DOC_INDEX (0-indexed: $i)..."
+    
+    # Create a temporary file for the current YAML document
+    TEMP_DOC_FILE=$(mktemp --suffix=".yml")
+    
+    # Extract the specific YAML document using yq and save it to the temporary file
+    # 'select(document_index == $i)' extracts the document at index i (0-based)
+    if ! yq e "select(document_index == $i)" "$YML_FILE" > "$TEMP_DOC_FILE"; then
+        echo "    Error: Failed to extract document $CURRENT_DOC_INDEX from $YML_FILE using yq. Skipping validation for this document."
+        FILE_HAS_ERRORS=true
+        TOTAL_DOCUMENTS_FAILED=$((TOTAL_DOCUMENTS_FAILED + 1))
+        rm -f "$TEMP_DOC_FILE"
+        continue
+    fi
+    
+    # Validate the temporary YAML file using ajv
+    # ajv will now handle the YAML parsing itself
+    ajv validate -s "$SCHEMA" -d "$TEMP_DOC_FILE"
+    AJV_EXIT_CODE=$?
+    
+    # Clean up the temporary file
+    rm -f "$TEMP_DOC_FILE"
+    
+    if [ $AJV_EXIT_CODE -ne 0 ]; then
+        echo "    --> Validation FAILED for document $CURRENT_DOC_INDEX"
+        FILE_HAS_ERRORS=true
+        TOTAL_DOCUMENTS_FAILED=$((TOTAL_DOCUMENTS_FAILED + 1))
+    else
+        echo "    --> Validation PASSED for document $CURRENT_DOC_INDEX"
+    fi
+done
+
+echo ""
+echo "--- Validation Summary for $YML_FILE ---"
+echo "Total documents validated:  $TOTAL_DOCUMENTS_VALIDATED"
+echo "Total documents failed:     $TOTAL_DOCUMENTS_FAILED"
+
+if [ "$FILE_HAS_ERRORS" = true ]; then
+    echo "Overall Validation: FAILED (Some documents contain errors)."
+    exit 1
+else
+    echo "Overall Validation: PASSED (All documents are valid)."
+    exit 0
+fi

--- a/scripts/validate_gfr.sh
+++ b/scripts/validate_gfr.sh
@@ -40,12 +40,11 @@ TOTAL_DOCUMENTS_VALIDATED=0
 TOTAL_DOCUMENTS_FAILED=0
 FILE_HAS_ERRORS=false
 
-echo "--- Starting Multi-Document YAML Validation ---"
+echo "==============================================="
 echo "File:   $YML_FILE"
-echo "Schema: $SCHEMA"
-echo "-----------------------------------------------"
+#echo "Schema: $SCHEMA"
 
-# --- CORRECTED: Get the number of documents in the YAML file ---
+# --- Get the number of documents in the YAML file ---
 # We use 'eval-all . | ""' to process each document and output an empty string,
 # then 'wc -l' to count the lines, which corresponds to the number of documents.
 NUM_DOCS=$(yq eval-all '. | ""' "$YML_FILE" 2>/dev/null | wc -l)
@@ -64,7 +63,7 @@ for (( i=0; i<NUM_DOCS; i++ )); do
     CURRENT_DOC_INDEX=$((i + 1))
     TOTAL_DOCUMENTS_VALIDATED=$((TOTAL_DOCUMENTS_VALIDATED + 1))
     
-    echo "  - Validating document $CURRENT_DOC_INDEX (0-indexed: $i)..."
+    echo "  - Validating document $CURRENT_DOC_INDEX ..."
     
     # Create a temporary file for the current YAML document. This works on both MacOS and Linux
     export TMPDIR="${TMPDIR:-/tmp}"
@@ -82,8 +81,7 @@ for (( i=0; i<NUM_DOCS; i++ )); do
     fi
     
     # Validate the temporary YAML file using ajv
-    # ajv will now handle the YAML parsing itself
-    ajv validate -s "$SCHEMA" -d "$TEMP_DOC_FILE"
+    ajv validate -s "$SCHEMA" -d "$TEMP_DOC_FILE" &> /dev/null
     AJV_EXIT_CODE=$?
     
     # Clean up the temporary file

--- a/scripts/validate_gfr.sh
+++ b/scripts/validate_gfr.sh
@@ -81,7 +81,7 @@ for (( i=0; i<NUM_DOCS; i++ )); do
     fi
     
     # Validate the temporary YAML file using ajv
-    ajv validate -s "$SCHEMA" -d "$TEMP_DOC_FILE" &> /dev/null
+    ajv validate -s "$SCHEMA" -d "$TEMP_DOC_FILE"
     AJV_EXIT_CODE=$?
     
     # Clean up the temporary file

--- a/scripts/validate_simple.sh
+++ b/scripts/validate_simple.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Define the path to the JSON schema, relative to this script's location.
+# Assuming schema.json is in the repository root.
+SCHEMA="$(dirname "$(realpath "$0")")/../schema.json"
+
+# --- Dependency Checks ---
+# Check if ajv-cli is installed
+if ! command -v ajv &> /dev/null; then
+    echo "Error: 'ajv' command not found."
+    echo "Please install ajv-cli globally: npm install -g ajv-cli"
+    exit 1
+fi
+# --- End Dependency Checks ---
+
+# Check if a YAML file was provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <path_to_yaml_file>"
+    echo "Example: $0 Pisum/sativum/studies/pissa.Sato_Morita_2007.yml"
+    echo ""
+    echo "NOTE: This script only works on yaml files that contain a single yaml document."
+    echo "NOTE: If your file has multiple yaml documents (separated by '---'), use validate_gfr.sh instead."
+    echo ""
+    exit 1
+fi
+
+YML_FILE="$1"
+
+# Check if the provided file exists
+if [ ! -f "$YML_FILE" ]; then
+    echo "Error: YAML file not found: $YML_FILE"
+    exit 1
+fi
+
+echo "--- Validating Single YAML File ---"
+echo "File:   $YML_FILE"
+echo "Schema: $SCHEMA"
+echo "-----------------------------------"
+
+# Validate the YAML file directly using ajv.
+# ajv will use its internal YAML parser to process the file.
+ajv validate -s "$SCHEMA" -d "$YML_FILE"
+AJV_EXIT_CODE=$?
+
+if [ $AJV_EXIT_CODE -ne 0 ]; then
+    echo "Validation FAILED for $YML_FILE"
+    exit 1
+else
+    echo "Validation PASSED for $YML_FILE"
+    exit 0
+fi


### PR DESCRIPTION
I have added two scripts to be used to validate new yaml documents.

The main script is `validate_gfr.sh`. It is called like so:
```
  ./scripts/validate_gfr.sh Pisum/sativum/studies/pissa.Feng_Chen_2024.yml
```

There is another script, `validate_simple.sh`, but this only works with files that contain a single yaml document, whereas `validate_gfr.sh` can process multi-document yaml files.

The script(s) can be run from the gene function registry at Ceres: `/project/legume_project/datastore/gene-function-registry`, using the conda environment `ds-curate` -- or at any local repository instance as long as you have `ajv-cli` and `yq` installed -- or in a Codespaces instance.