### PR TITLE
Glyma.jahan harris 2020

### DIFF
--- a/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
+++ b/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
@@ -2,55 +2,83 @@
 scientific_name: Glycine max
 gene_symbols:
   - GmMYB29A2
-gene_symbol_long: 
+gene_symbol_long: Glyceollin R2R3-type MYB Transcription Factor A2
 gene_model_pub_name: Glyma.02G005600
 gene_model_full_id: glyma.Wm82.gnm4.ann1.Glyma.02G005600
 confidence: 4
 curators:
   - Molly Hardacre
 comments:
-  - Overexpression and RNA interference silencing of GmMYB29A2 increased and decreased expression of GmNAC42-1, GmMYB29A1, and glyceollin biosynthesis genes and metabolites, respectively, in response to wall glucan elicitor.
-  - GmMYB29A2 interacted with the promoters of two glyceollin I biosynthesis genes in vitro and in vivo
-  - GmMYB29A2 would be required for stimulating glyceollin biosynthesis in part by up-regulating GmNAC42-1
-  - GmMYB29A2 in Williams 82, a soybean variety that encodes the resistance gene Rps1k, rendered it compatible with race 1 P. sojae, whereas overexpressing GmMYB29A2 rendered the susceptible Williams variety incompatible.
-  - Compatibility and incompatibility coincided with reduced and enhanced accumulations of glyceollin I but not other 5-deoxyisoflavonoids.
-  - Silencing either GmMYB29A2 or GmMYB29A1 in W82 hairy roots decreased the accumulations of glyceollin I metabolites, but silencing specifically GmMYB29A2 reduced the expression of GmNAC42-1 and most glyceollin biosynthesis genes
-phenotype_synopsis:
+  - Overexpression and RNA interference silencing of GmMYB29A2 increased and
+    decreased expression of GmNAC42-1, GmMYB29A1, and glyceollin biosynthesis
+    genes and metabolites, respectively, in response to wall glucan elicitor
+    from Phytophthora sojae
+  - GmMYB29A2 directly binds promoters of glyceollin‑biosynthesis genes.
+    GmMYB29A2 interacted with the promoters of two glyceollin I biosynthesis
+    genes in vitro and in vivo
+  - GmMYB29A2 in Williams 82, a soybean variety that encodes the resistance gene
+    Rps1k, rendered it compatible with race 1 Phytophthora sojae, whereas
+    overexpressing GmMYB29A2 rendered the susceptible Williams variety
+    incompatible.
+  - GmMYB29A2 specifically boosts glyceollin I, not all isoflavonoids.
+    Compatibility and incompatibility coincided with reduced and enhanced
+    accumulations of glyceollin I but not other 5-deoxyisoflavonoids.
+  - Silencing either GmMYB29A2 or GmMYB29A1 in W82 hairy roots decreased the
+    accumulations of glyceollin I metabolites, but silencing specifically
+    GmMYB29A2 reduced the expression of GmNAC42-1 and most glyceollin
+    biosynthesis genes
+phenotype_synopsis: GmMYB29A2 is a core activator of glyceollin biosynthesis
+  that is essential for disease resistance against Phytophthora sojae
 traits:
   - entity_name: Oomycete disease response
     entity: TO:0001144
-  - entity_name: glyceollin biosynthesis
-    entity: UPa_UPA00898
+  - entity_name: glyceollin synthase activity
+    entity: GO:0033769
 references:
   - citation: Jahan, Harris et al., 2020
     doi: 10.1104/pp.19.01293
     pmid: 32209590
----
 
+---
 scientific_name: Glycine max
 gene_symbols:
   - GmMYB29A1
-gene_symbol_long: 
+gene_symbol_long: Glyceollin R2R3-type MYB Transcription Factor A2
 gene_model_pub_name: Glyma.10G006600
 gene_model_full_id: glyma.Wm82.gnm4.ann1.Glyma.10G006600
 confidence: 4
 curators:
   - Molly Hardacre
 comments:
-  - Overexpressing or silencing GmMYB29A1 decreased glyceollin I accumulation with marginal or no effects on the expressions of glyceollin synthesis genes, suggesting a preferential role in promoting glyceollin turnover and/or competing biosynthetic pathways
-  - Overexpressing GmMYB29A1 in W82 hairy roots demonstrated that GmMYB29A1 slightly down-regulated GmMYB29A2 and G4DT but not other glyceollin biosynthesis genes
-  - GmMYB29A2 and GmMYB29A1 had only one amino acid difference in their SG2 motif, specifically at amino acid 192 
-  - GmMYB29A1 may regulate glyceollin turnover or competing pathways, by having have a preferential role in promoting glyceollin turnover and/or competing biosynthetic pathways
-  - GmMYB29A1 marginally affected the expressions of most glyceollin biosynthetic genes, we suggest that it reduced glyceollin I levels by inducing the expressions of metabolizing enzymes. Thus, the role of GmMYB29A1 may be to limit glyceollin I levels.
-phenotype_synopsis:
+  - GmMYB29A1 does not activate glyceollin biosynthesis genes strongly.
+    Overexpressing or silencing GmMYB29A1 decreased glyceollin I accumulation
+    with marginal or no effects on the expressions of glyceollin synthesis
+    genes.
+  - Overexpressing GmMYB29A1 in W82 hairy roots demonstrated that GmMYB29A1
+    slightly down-regulated GmMYB29A2 and G4DT but not other glyceollin
+    biosynthesis genes
+  - GmMYB29A2 and GmMYB29A1 had only one amino acid difference in their SG2
+    motif, specifically at amino acid 192. Amino acid sequence analysis found
+    that GmMYB29A1 and GmMYB29A2 proteins encoded R2R3 DNA binding domains in
+    their N-terminal regions where they were 100% identical to each other
+  - GmMYB29A1 may regulate glyceollin turnover or competing pathways, by having
+    have a preferential role in promoting glyceollin turnover and/or competing
+    biosynthetic pathways
+  - GmMYB29A1 marginally affected the expressions of most glyceollin
+    biosynthetic genes, data suggests that it reduced glyceollin I levels by
+    inducing the expressions of metabolizing enzymes. Thus, the role of
+    GmMYB29A1 may be to limit glyceollin I levels.
+phenotype_synopsis: GmMYB29A1 affects glyceollin levels but mainly by
+  influencing turnover or side‑pathways, not by activating glyceollin
+  biosynthesis for disease resistance against Phytophthora sojae
 traits:
   - entity_name: Oomycete disease response
     entity: TO:0001144
-  - entity_name: glyceollin biosynthesis
-    entity: UPa_UPA00898
+  - entity_name: glyceollin synthase activity
+    entity: GO:0033769
 references:
   - citation: Jahan, Harris et al., 2020
     doi: 10.1104/pp.19.01293
     pmid: 32209590
 
----
+

--- a/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
+++ b/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
@@ -8,19 +8,20 @@ gene_model_full_id: glyma.Wm82.gnm4.ann1.Glyma.02G005600
 confidence: 4
 curators:
   - Molly Hardacre
+  - Scott Kalberer
 comments:
   - Overexpression and RNA interference silencing of GmMYB29A2 increased and
     decreased expression of GmNAC42-1, GmMYB29A1, and glyceollin biosynthesis
     genes and metabolites, respectively, in response to wall glucan elicitor
     from Phytophthora sojae.
-  - GmMYB29A2 directly binds promoters of glyceollin‑biosynthesis genes.
+  - GmMYB29A2 directly binds to promoters of glyceollin‑biosynthesis genes.
     GmMYB29A2 interacted with the promoters of two glyceollin I biosynthesis
     genes in vitro and in vivo.
-  - GmMYB29A2 in Williams 82, a soybean variety that encodes the resistance gene
-    Rps1k, rendered it compatible with race 1 Phytophthora sojae, whereas
-    overexpressing GmMYB29A2 rendered the susceptible Williams variety
-    incompatible.
-  - GmMYB29A2 specifically boosts glyceollin I, not all isoflavonoids.
+  - Silencing GmMYB29A2 in Williams 82, a soybean variety that encodes the
+    resistance gene Rps1k, rendered it compatible with race 1 Phytophthora
+    sojae, whereas overexpressing GmMYB29A2 rendered the susceptible Williams
+    variety incompatible.
+  - GmMYB29A2 specifically boosts glyceollin I isomer, not all isoflavonoids.
     Compatibility and incompatibility coincided with reduced and enhanced
     accumulations of glyceollin I but not other 5-deoxyisoflavonoids.
   - Silencing either GmMYB29A2 or GmMYB29A1 in W82 hairy roots decreased the
@@ -34,6 +35,8 @@ traits:
     entity: TO:0001144
   - entity_name: glyceollin synthase activity
     entity: GO:0033769
+  - entity_name: phytoalexin content
+    entity: TO:0002669
 references:
   - citation: Jahan, Harris et al., 2020
     doi: 10.1104/pp.19.01293
@@ -49,11 +52,12 @@ gene_model_full_id: glyma.Wm82.gnm4.ann1.Glyma.10G006600
 confidence: 4
 curators:
   - Molly Hardacre
+  - Scott Kalberer
 comments:
   - GmMYB29A1 does not activate glyceollin biosynthesis genes strongly.
-    Overexpressing or silencing GmMYB29A1 decreased glyceollin I accumulation
-    with marginal or no effects on the expressions of glyceollin synthesis
-    genes.
+    Overexpressing or silencing GmMYB29A1 decreased glyceollin I isomer
+    accumulation with marginal or no effects on the expressions of glyceollin
+    synthesis genes.
   - Overexpressing GmMYB29A1 in W82 hairy roots demonstrated that GmMYB29A1
     slightly down-regulated GmMYB29A2 and G4DT but not other glyceollin
     biosynthesis genes.
@@ -61,11 +65,10 @@ comments:
     motif, specifically at amino acid 192. Amino acid sequence analysis found
     that GmMYB29A1 and GmMYB29A2 proteins encoded R2R3 DNA binding domains in
     their N-terminal regions where they were 100% identical to each other.
-  - GmMYB29A1 may regulate glyceollin turnover or competing pathways, by having
-    have a preferential role in promoting glyceollin turnover and/or competing
-    biosynthetic pathways.
+  - GmMYB29A1 may have a preferential role in promoting or regulating glyceollin
+    turnover and/or competing biosynthetic pathways.
   - GmMYB29A1 marginally affected the expressions of most glyceollin
-    biosynthetic genes, data suggests that it reduced glyceollin I levels by
+    biosynthetic genes; data suggests it reduced glyceollin I levels by
     inducing the expressions of metabolizing enzymes. Thus, the role of
     GmMYB29A1 may be to limit glyceollin I levels.
 phenotype_synopsis: GmMYB29A1 affects glyceollin levels but mainly by
@@ -76,6 +79,8 @@ traits:
     entity: TO:0001144
   - entity_name: glyceollin synthase activity
     entity: GO:0033769
+  - entity_name: phytoalexin content
+    entity: TO:0002669
 references:
   - citation: Jahan, Harris et al., 2020
     doi: 10.1104/pp.19.01293

--- a/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
+++ b/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
@@ -1,0 +1,56 @@
+---
+scientific_name: Glycine max
+gene_symbols:
+  - GmMYB29A2
+gene_symbol_long: 
+gene_model_pub_name: Glyma.02G005600
+gene_model_full_id: glyma.Wm82.gnm4.ann1.Glyma.02G005600
+confidence: 4
+curators:
+  - Molly Hardacre
+comments:
+  - Overexpression and RNA interference silencing of GmMYB29A2 increased and decreased expression of GmNAC42-1, GmMYB29A1, and glyceollin biosynthesis genes and metabolites, respectively, in response to wall glucan elicitor.
+  - GmMYB29A2 interacted with the promoters of two glyceollin I biosynthesis genes in vitro and in vivo
+  - GmMYB29A2 would be required for stimulating glyceollin biosynthesis in part by up-regulating GmNAC42-1
+  - GmMYB29A2 in Williams 82, a soybean variety that encodes the resistance gene Rps1k, rendered it compatible with race 1 P. sojae, whereas overexpressing GmMYB29A2 rendered the susceptible Williams variety incompatible.
+  - Compatibility and incompatibility coincided with reduced and enhanced accumulations of glyceollin I but not other 5-deoxyisoflavonoids.
+  - Silencing either GmMYB29A2 or GmMYB29A1 in W82 hairy roots decreased the accumulations of glyceollin I metabolites, but silencing specifically GmMYB29A2 reduced the expression of GmNAC42-1 and most glyceollin biosynthesis genes
+phenotype_synopsis:
+traits:
+  - entity_name: Oomycete disease response
+    entity: TO:0001144
+  - entity_name: glyceollin biosynthesis
+    entity: UPa_UPA00898
+references:
+  - citation: Jahan, Harris et al., 2020
+    doi: 10.1104/pp.19.01293
+    pmid: 32209590
+---
+
+scientific_name: Glycine max
+gene_symbols:
+  - GmMYB29A1
+gene_symbol_long: 
+gene_model_pub_name: Glyma.10G006600
+gene_model_full_id: glyma.Wm82.gnm4.ann1.Glyma.10G006600
+confidence: 4
+curators:
+  - Molly Hardacre
+comments:
+  - Overexpressing or silencing GmMYB29A1 decreased glyceollin I accumulation with marginal or no effects on the expressions of glyceollin synthesis genes, suggesting a preferential role in promoting glyceollin turnover and/or competing biosynthetic pathways
+  - Overexpressing GmMYB29A1 in W82 hairy roots demonstrated that GmMYB29A1 slightly down-regulated GmMYB29A2 and G4DT but not other glyceollin biosynthesis genes
+  - GmMYB29A2 and GmMYB29A1 had only one amino acid difference in their SG2 motif, specifically at amino acid 192 
+  - GmMYB29A1 may regulate glyceollin turnover or competing pathways, by having have a preferential role in promoting glyceollin turnover and/or competing biosynthetic pathways
+  - GmMYB29A1 marginally affected the expressions of most glyceollin biosynthetic genes, we suggest that it reduced glyceollin I levels by inducing the expressions of metabolizing enzymes. Thus, the role of GmMYB29A1 may be to limit glyceollin I levels.
+phenotype_synopsis:
+traits:
+  - entity_name: Oomycete disease response
+    entity: TO:0001144
+  - entity_name: glyceollin biosynthesis
+    entity: UPa_UPA00898
+references:
+  - citation: Jahan, Harris et al., 2020
+    doi: 10.1104/pp.19.01293
+    pmid: 32209590
+
+---

--- a/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
+++ b/Glycine/max/studies/glyma.Jahan_Harris_2020.yml
@@ -12,10 +12,10 @@ comments:
   - Overexpression and RNA interference silencing of GmMYB29A2 increased and
     decreased expression of GmNAC42-1, GmMYB29A1, and glyceollin biosynthesis
     genes and metabolites, respectively, in response to wall glucan elicitor
-    from Phytophthora sojae
+    from Phytophthora sojae.
   - GmMYB29A2 directly binds promoters of glyceollin‑biosynthesis genes.
     GmMYB29A2 interacted with the promoters of two glyceollin I biosynthesis
-    genes in vitro and in vivo
+    genes in vitro and in vivo.
   - GmMYB29A2 in Williams 82, a soybean variety that encodes the resistance gene
     Rps1k, rendered it compatible with race 1 Phytophthora sojae, whereas
     overexpressing GmMYB29A2 rendered the susceptible Williams variety
@@ -26,9 +26,9 @@ comments:
   - Silencing either GmMYB29A2 or GmMYB29A1 in W82 hairy roots decreased the
     accumulations of glyceollin I metabolites, but silencing specifically
     GmMYB29A2 reduced the expression of GmNAC42-1 and most glyceollin
-    biosynthesis genes
+    biosynthesis genes.
 phenotype_synopsis: GmMYB29A2 is a core activator of glyceollin biosynthesis
-  that is essential for disease resistance against Phytophthora sojae
+  that is essential for disease resistance against Phytophthora sojae.
 traits:
   - entity_name: Oomycete disease response
     entity: TO:0001144
@@ -56,21 +56,21 @@ comments:
     genes.
   - Overexpressing GmMYB29A1 in W82 hairy roots demonstrated that GmMYB29A1
     slightly down-regulated GmMYB29A2 and G4DT but not other glyceollin
-    biosynthesis genes
+    biosynthesis genes.
   - GmMYB29A2 and GmMYB29A1 had only one amino acid difference in their SG2
     motif, specifically at amino acid 192. Amino acid sequence analysis found
     that GmMYB29A1 and GmMYB29A2 proteins encoded R2R3 DNA binding domains in
-    their N-terminal regions where they were 100% identical to each other
+    their N-terminal regions where they were 100% identical to each other.
   - GmMYB29A1 may regulate glyceollin turnover or competing pathways, by having
     have a preferential role in promoting glyceollin turnover and/or competing
-    biosynthetic pathways
+    biosynthetic pathways.
   - GmMYB29A1 marginally affected the expressions of most glyceollin
     biosynthetic genes, data suggests that it reduced glyceollin I levels by
     inducing the expressions of metabolizing enzymes. Thus, the role of
     GmMYB29A1 may be to limit glyceollin I levels.
 phenotype_synopsis: GmMYB29A1 affects glyceollin levels but mainly by
   influencing turnover or side‑pathways, not by activating glyceollin
-  biosynthesis for disease resistance against Phytophthora sojae
+  biosynthesis for disease resistance against Phytophthora sojae.
 traits:
   - entity_name: Oomycete disease response
     entity: TO:0001144
@@ -80,5 +80,3 @@ references:
   - citation: Jahan, Harris et al., 2020
     doi: 10.1104/pp.19.01293
     pmid: 32209590
-
-


### PR DESCRIPTION
Intriguing paper! For the long name, I added in a word about Glyceollin since it's labelled as a Glyceollin Transcription Factor for both genes, yet they're both MYB transcription factor genes (so let me know if I should leave that in or maybe take it out). GmMYB29A2 seemed like it was a key regulator, while GmMYB29A1 seemed less integral and moved through side pathways which I tried to describe to the best of my ability in the comments but let me know if more info is probably needed. Also tried to pin down two traits that seemed pretty applicable - there was one trait in the ontology service that was about glyceollin biosynthesis but it wasn't under TO or GO (UPa_UPA00898) so I decided to omit and opt for a better one in the paper. Let me know what you think! - Molly :)