### PR TITLE
Glyso.sun yu 2026

### DIFF
--- a/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
+++ b/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
@@ -1,0 +1,48 @@
+---
+scientific_name: Glycine soja
+gene_symbols:
+  - GsWRKY23 
+gene_symbol_long: Transcription factor WRKY
+gene_model_pub_name: 
+gene_model_full_id:
+confidence:
+curators:
+  -
+comments:
+  -
+phenotype_synopsis:
+traits:
+  - entity_name:
+    entity:
+references:
+  - citation: Sun, Yu et al., 2026
+    doi: 10.1016/j.plaphy.2026.111035
+    pmid: 41548341
+  - citation:
+    doi:
+    pmid:
+---
+
+scientific_name: Glycine soja
+gene_symbols:
+  - GsPER3
+gene_symbol_long: 
+gene_model_pub_name: Glysoja.10G025790
+gene_model_full_id: glyso.W05.gnm1.ann1.Glysoja.10G025790
+confidence:
+curators:
+  - Molly Hardacre
+comments:
+  -
+phenotype_synopsis:
+traits:
+  - entity_name:
+    entity:
+references:
+  - citation: Sun, Yu et al., 2026
+    doi: 10.1016/j.plaphy.2026.111035
+    pmid: 41548341
+  - citation:
+    doi:
+    pmid:
+---

--- a/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
+++ b/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
@@ -2,20 +2,20 @@
 scientific_name: Glycine soja
 gene_symbols:
   - GsWRKY23
-gene_symbol_long: Transcription factor WRKY 23
+gene_symbol_long: Transcription Factor WRKY 23
 gene_model_pub_name: Glysoja.02G002639
 gene_model_full_id: glyso.W05.gnm1.ann1.Glysoja.02G002639
 confidence: 5
 curators:
   - Molly Hardacre
 comments:
-  - GsWRKY23 specifically binds to the W-box element at position -486 in the
+  - GsWRKY23 specifically binds to the W-box element at position-486 in the
     promoter of GsPER3, thereby transcriptionally activating its expression.
   - Under salt stress treatment, GsWRKY23-overexpression soybean plants
     exhibited upregulated root GsPER3 expression, and elevated peroxidase
     activity in both roots and leaves as compared to empty vector controls.
   - The Glysoja.02G002639 name of the gene model was taken from Sun, Liu et al.,
-    2023
+    2023.
 phenotype_synopsis: GsWRKY23 enhances salt tolerance by activating antioxidant
   defenses through GsPER3.
 traits:
@@ -48,10 +48,10 @@ comments:
     superior performance in physiological parameters including plant fresh
     weight, leaf relative water content, as well as lower relative electrolytic
     leakage levels.
-  - GsPER3-overexpression also showed reduced malondialdehyde content, reactive
+  - GsPER3-overexpression also showed reduced malondialdehyde content, lower reactive
     oxygen species accumulation, and higher antioxidant enzyme activities,
     whereas GsPER3-Cas9 plants showed the opposite trends.
-phenotype_synopsis: GsPER3 enhances salt‑stress with lowering oxidative damage,
+phenotype_synopsis: GsPER3 enhances salt‑stress by lowering oxidative damage,
   increasing antioxidant enzyme activity, and preserving plant water content,
   which results in higher fresh weight/improved plant performance.
 traits:

--- a/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
+++ b/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
@@ -14,11 +14,15 @@ comments:
   - Under salt stress treatment, GsWRKY23-overexpression soybean plants
     exhibited upregulated root GsPER3 expression, and elevated peroxidase
     activity in both roots and leaves as compared to empty vector controls.
+  - The Glysoja.02G002639 name of the gene model was taken from Sun, Liu et al.,
+    2023
 phenotype_synopsis: GsWRKY23 enhances salt tolerance by activating antioxidant
   defenses through GsPER3.
 traits:
   - entity_name: salt tolerance
     entity: TO:0006001
+  - entity_name: oxidative stress response
+    entity: TO:0002657
   - entity_name: peroxidase activity
     entity: GO:0004601
 references:
@@ -53,6 +57,8 @@ phenotype_synopsis: GsPER3 enhances salt‑stress with lowering oxidative damage
 traits:
   - entity_name: salt tolerance
     entity: TO:0006001
+  - entity_name: oxidative stress response
+    entity: TO:0002657
   - entity_name: plant fresh weight
     entity: TO:0000442
   - entity_name: leaf relative water content
@@ -61,7 +67,4 @@ references:
   - citation: Sun, Yu et al., 2026
     doi: 10.1016/j.plaphy.2026.111035
     pmid: 41548341
-  - citation: Sun, Liu et al., 2023
-    doi: 10.3390/plants12173030
-    pmid: 37687277
 

--- a/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
+++ b/Glycine/soja/studies/glyso.Sun_Yu_2026.yml
@@ -1,48 +1,67 @@
 ---
 scientific_name: Glycine soja
 gene_symbols:
-  - GsWRKY23 
-gene_symbol_long: Transcription factor WRKY
-gene_model_pub_name: 
-gene_model_full_id:
-confidence:
-curators:
-  -
-comments:
-  -
-phenotype_synopsis:
-traits:
-  - entity_name:
-    entity:
-references:
-  - citation: Sun, Yu et al., 2026
-    doi: 10.1016/j.plaphy.2026.111035
-    pmid: 41548341
-  - citation:
-    doi:
-    pmid:
----
-
-scientific_name: Glycine soja
-gene_symbols:
-  - GsPER3
-gene_symbol_long: 
-gene_model_pub_name: Glysoja.10G025790
-gene_model_full_id: glyso.W05.gnm1.ann1.Glysoja.10G025790
-confidence:
+  - GsWRKY23
+gene_symbol_long: Transcription factor WRKY 23
+gene_model_pub_name: Glysoja.02G002639
+gene_model_full_id: glyso.W05.gnm1.ann1.Glysoja.02G002639
+confidence: 5
 curators:
   - Molly Hardacre
 comments:
-  -
-phenotype_synopsis:
+  - GsWRKY23 specifically binds to the W-box element at position -486 in the
+    promoter of GsPER3, thereby transcriptionally activating its expression.
+  - Under salt stress treatment, GsWRKY23-overexpression soybean plants
+    exhibited upregulated root GsPER3 expression, and elevated peroxidase
+    activity in both roots and leaves as compared to empty vector controls.
+phenotype_synopsis: GsWRKY23 enhances salt tolerance by activating antioxidant
+  defenses through GsPER3.
 traits:
-  - entity_name:
-    entity:
+  - entity_name: salt tolerance
+    entity: TO:0006001
+  - entity_name: peroxidase activity
+    entity: GO:0004601
 references:
   - citation: Sun, Yu et al., 2026
     doi: 10.1016/j.plaphy.2026.111035
     pmid: 41548341
-  - citation:
-    doi:
-    pmid:
+  - citation: Sun, Liu et al., 2023
+    doi: 10.3390/plants12173030
+    pmid: 37687277
+
 ---
+scientific_name: Glycine soja
+gene_symbols:
+  - GsPER3
+gene_symbol_long: Peroxidase 3
+gene_model_pub_name: Glysoja.10G025790
+gene_model_full_id: glyso.W05.gnm1.ann1.Glysoja.10G025790
+confidence: 5
+curators:
+  - Molly Hardacre
+comments:
+  - GsPER3-overexpression plants displayed enhanced salt tolerance, with
+    superior performance in physiological parameters including plant fresh
+    weight, leaf relative water content, as well as lower relative electrolytic
+    leakage levels.
+  - GsPER3-overexpression also showed reduced malondialdehyde content, reactive
+    oxygen species accumulation, and higher antioxidant enzyme activities,
+    whereas GsPER3-Cas9 plants showed the opposite trends.
+phenotype_synopsis: GsPER3 enhances salt‑stress with lowering oxidative damage,
+  increasing antioxidant enzyme activity, and preserving plant water content,
+  which results in higher fresh weight/improved plant performance.
+traits:
+  - entity_name: salt tolerance
+    entity: TO:0006001
+  - entity_name: plant fresh weight
+    entity: TO:0000442
+  - entity_name: leaf relative water content
+    entity: TO:0000136
+references:
+  - citation: Sun, Yu et al., 2026
+    doi: 10.1016/j.plaphy.2026.111035
+    pmid: 41548341
+  - citation: Sun, Liu et al., 2023
+    doi: 10.3390/plants12173030
+    pmid: 37687277
+


### PR DESCRIPTION
Zotero paper, pretty good! Both of the traits had knockouts but I had to grab the pub_name for the first grene from the second citation, so that's why it's there. Wasn't entirely sure if the second trait was just called Peroxidase 3 for the long name, I assumed it was from this sentence, "In this study, we identified GsPER3 as a class III peroxidase comprising 322 amino acids...", but let me know if that doesn't seem right. Thanks and let me know! - Molly :)