### PR TITLE
Phavu weller vander schoor 2019

### DIFF
--- a/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
+++ b/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
@@ -4,46 +4,21 @@ classical_locus: Ppd
 gene_symbols: PHYA3
 gene_symbol_long: Phytochrome A
 gene_model_pub_name: Phvul.001G221100
-gene_model_full_id:
-confidence:
+gene_model_full_id: phavu.G19833.gnm1.ann1.Phvul.001G221100
+confidence: 3
 curators:
   -Amy Pollpeter
 comments:
   - Wild accessions - G12873 from mesoamerica - indeterminate growth habit, photoperiod sensitive (requires short days).
   - Domesticated accession - cv. Midas - from Andean - determinate growth habit, photoperiod insensitive (grows and flowers in long days)
-  - These traits previously associated with 2 loci on Chromosome 1. Fin - Indeterminate growth, fin - determinate growth; Ppd - photoperiod sensitive, ppd - photoperiod insensitive
-  - 
+  - These traits previously associated with 2 loci on Chromosome 1. Fin - Indeterminate growth, fin - determinate growth; Ppd - photoperiod sensitive, ppd - photoperiod insensitive.
+  - Fin previously associated with TFL1y gene.
+  - Identified a deleterious PHYA3 sequence in ppd (photoperiod insensitive) plants in several accessions of Andean origin.
+  - 2nd deleterious allel present in photoperiod insensitive ppd plants in some Mesoamerican accessions.
+  - PHYA3 and Ppd have been associated to each other in other legumes (soybean).
 phenotype_synopsis:
 references:
   - citation: Weller, Vander Schoor et al., 2019
     doi: 10.1093/jxb/ery455
     pmid: 31222352
-  - citation:
-    doi:
-    pmid:
----
-scientific_name: Phaseolus vulgaris
-classical_locus:
-gene_symbols: TFL1y
-  - 
-gene_symbol_long:
-gene_model_pub_name: PhvulG189200
-gene_model_full_id:
-confidence:
-curators:
-  -Amy Pollpeter
-comments: 
-
-phenotype_synopsis: 
-
-traits:
-  - entity_name:
-    entity:
-references:
-  - citation: Weller, Vander Schoor et al., 2019
-    doi: 10.1093/jxb/ery455
-    pmid: 31222352
-  - citation:
-    doi:
-    pmid:
 ---

--- a/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
+++ b/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
@@ -1,5 +1,4 @@
 ---
-# IN PROCESS
 scientific_name: Phaseolus vulgaris
 classical_locus:
 gene_symbols: PHYA3
@@ -13,7 +12,16 @@ curators:
 comments:
   -
 phenotype_synopsis: PHYA3 identified as strong candidate for Ppd (Photoperiod insensitive) phenotype allowing for flowering in long day conditions.
-
+references:
+  - citation: Weller, Vander Schoor et al., 2019
+    doi: 10.1093/jxb/ery455
+    pmid: 31222352
+  - citation:
+    doi:
+    pmid:
+---
+scientific_name: Phaseolus vulgaris
+classical_locus:
 gene_symbols: TFL1y
   - 
 gene_symbol_long:

--- a/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
+++ b/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
@@ -12,7 +12,8 @@ curators:
   -Amy Pollpeter
 comments:
   -
-phenotype_synopsis:
+phenotype_synopsis: PHYA3 identified as strong candidate for Ppd (Photoperiod insensitive) phenotype allowing for flowering in long day conditions.
+
 traits:
   - entity_name:
     entity:

--- a/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
+++ b/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
@@ -6,19 +6,34 @@ gene_symbol_long: Phytochrome A
 gene_model_pub_name: Phvul.001G221100
 gene_model_full_id: phavu.G19833.gnm1.ann1.Phvul.001G221100
 confidence: 3
-curators:
-  -Amy Pollpeter
+curators: -Amy Pollpeter
 comments:
-  - Wild accessions - G12873 from mesoamerica - indeterminate growth habit, photoperiod sensitive (requires short days).
-  - Domesticated accession - cv. Midas - from Andean - determinate growth habit, photoperiod insensitive (grows and flowers in long days)
-  - These traits previously associated with 2 loci on Chromosome 1. Fin - Indeterminate growth, fin - determinate growth; Ppd - photoperiod sensitive, ppd - photoperiod insensitive.
+  - Wild accessions - G12873 from mesoamerica - indeterminate growth habit,
+    photoperiod sensitive (requires short days).
+  - Domesticated accession - cv. Midas - from Andean - determinate growth habit,
+    photoperiod insensitive (grows and flowers in long days)
+  - These traits previously associated with 2 loci on Chromosome 1. Fin -
+    Indeterminate growth, fin - determinate growth; Ppd - photoperiod sensitive,
+    ppd - photoperiod insensitive.
   - Fin previously associated with TFL1y gene.
-  - Identified a deleterious PHYA3 sequence in ppd (photoperiod insensitive) plants in several accessions of Andean origin.
-  - 2nd deleterious allel present in photoperiod insensitive ppd plants in some Mesoamerican accessions.
+  - Identified a deleterious PHYA3 sequence in ppd (photoperiod insensitive)
+    plants in several accessions of Andean origin.
+  - 2nd deleterious allel present in photoperiod insensitive ppd plants in some
+    Mesoamerican accessions.
   - PHYA3 and Ppd have been associated to each other in other legumes (soybean).
 phenotype_synopsis:
+  - Loss of function mutations in the PHYA3 gene result in photoperiod
+    insensitive plants that show early flowering behavior without the short day
+    requirement of wild accessions.
+  - Two different mutations appear to have resulted in this same phenotype in
+    two different lines of common bean. One in the mesoamerican lineage and one
+    in the Andean lineage.
+  - There is evidence for an epistatic interaction between the Ppd locus
+    associated with PHYA3 and the Fin locus associated with
+    indeterminate/determinate growth habits.
 references:
   - citation: Weller, Vander Schoor et al., 2019
     doi: 10.1093/jxb/ery455
     pmid: 31222352
+
 ---

--- a/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
+++ b/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
@@ -3,9 +3,9 @@
 scientific_name: Phaseolus vulgaris
 classical_locus:
 gene_symbols: PHYA3
-  -
-gene_symbol_long:
-gene_model_pub_name:
+  - 
+gene_symbol_long: Phytochrome A
+gene_model_pub_name: PhvulG221100
 gene_model_full_id:
 confidence:
 curators:
@@ -13,6 +13,18 @@ curators:
 comments:
   -
 phenotype_synopsis: PHYA3 identified as strong candidate for Ppd (Photoperiod insensitive) phenotype allowing for flowering in long day conditions.
+
+gene_symbols: TFL1y
+  - 
+gene_symbol_long:
+gene_model_pub_name: PhvulG189200
+gene_model_full_id:
+confidence:
+curators:
+  -Amy Pollpeter
+comments: 
+
+phenotype_synopsis: 
 
 traits:
   - entity_name:

--- a/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
+++ b/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
@@ -1,17 +1,19 @@
 ---
 scientific_name: Phaseolus vulgaris
-classical_locus:
+classical_locus: Ppd
 gene_symbols: PHYA3
-  - 
 gene_symbol_long: Phytochrome A
-gene_model_pub_name: PhvulG221100
+gene_model_pub_name: Phvul.001G221100
 gene_model_full_id:
 confidence:
 curators:
   -Amy Pollpeter
 comments:
-  -
-phenotype_synopsis: PHYA3 identified as strong candidate for Ppd (Photoperiod insensitive) phenotype allowing for flowering in long day conditions.
+  - Wild accessions - G12873 from mesoamerica - indeterminate growth habit, photoperiod sensitive (requires short days).
+  - Domesticated accession - cv. Midas - from Andean - determinate growth habit, photoperiod insensitive (grows and flowers in long days)
+  - These traits previously associated with 2 loci on Chromosome 1. Fin - Indeterminate growth, fin - determinate growth; Ppd - photoperiod sensitive, ppd - photoperiod insensitive
+  - 
+phenotype_synopsis:
 references:
   - citation: Weller, Vander Schoor et al., 2019
     doi: 10.1093/jxb/ery455

--- a/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
+++ b/Phaseolus/vulgaris/studies/phavu.Weller_VanderSchoor_2019.yml
@@ -1,0 +1,26 @@
+---
+# IN PROCESS
+scientific_name: Phaseolus vulgaris
+classical_locus:
+gene_symbols: PHYA3
+  -
+gene_symbol_long:
+gene_model_pub_name:
+gene_model_full_id:
+confidence:
+curators:
+  -Amy Pollpeter
+comments:
+  -
+phenotype_synopsis:
+traits:
+  - entity_name:
+    entity:
+references:
+  - citation: Weller, Vander Schoor et al., 2019
+    doi: 10.1093/jxb/ery455
+    pmid: 31222352
+  - citation:
+    doi:
+    pmid:
+---


### PR DESCRIPTION
This was the other FT paper Steven suggested to me.  Ppd locus associated  with photoperiod insensitivity was preliminarily associated with PHYA3 gene. I gave a confidence of 3.